### PR TITLE
Detect and warn of duplicates

### DIFF
--- a/adjustcaps.py
+++ b/adjustcaps.py
@@ -17,7 +17,7 @@ from obj_io import read_obj, write_obj
 from os import makedirs, remove, walk
 from os.path import basename, exists, join
 from positions import resolve_cap_position, translate_to_origin
-from util import concat, dict_union, flatten_list, get_only, list_diff, inner_join, rem
+from util import concat, dict_union, flatten_list, get_dicts_with_duplicate_field_values, get_only, list_diff, inner_join, rem
 from sys import argv, exit
 from yaml_io import read_yaml
 
@@ -105,7 +105,11 @@ def adjust_caps(layout: [dict], pargs:Namespace) -> str:
 
 def get_data(layout: [dict], cap_dir: str) -> [dict]:
     printi('Finding and parsing cap models')
+    # Get caps, check for duplicates
     caps: [dict] = get_caps(cap_dir)
+    duplicate_cap_names:[str] = list(map(lambda c: c[1][0]['cap-name'] + ' @ ' + ', '.join(list(map(lambda c2: c2['cap-source'], c[1]))), get_dicts_with_duplicate_field_values(caps, 'cap-name').items()))
+    if duplicate_cap_names != []:
+        printw('Duplicate keycap names detected:\n\t' + '\n\t'.join(duplicate_cap_names))
     layout_with_caps: [dict] = inner_join(caps, 'cap-name', layout, 'cap-name')
 
     # Warn about missing models

--- a/adjustglyphs.py
+++ b/adjustglyphs.py
@@ -8,12 +8,12 @@ if blender_available():
 from args import parse_args, Namespace
 from functools import reduce
 from layout import get_layout, parse_layout
-from log import die, init_logging, printi
+from log import die, init_logging, printi, printw
 from glyphinf import glyph_inf
 from os import remove, walk
 from os.path import exists, join
 from positions import resolve_glyph_positions
-from util import concat, dict_union, inner_join, list_diff, rob_rem
+from util import concat, dict_union, get_dicts_with_duplicate_field_values, inner_join, list_diff, rob_rem
 from re import match
 from scale import get_scale
 from sys import argv, exit
@@ -130,6 +130,10 @@ def collect_data(layout: [dict], profile_file: str, glyph_dir: str,
         }, profile['y-offsets'].items()))
     profile_special_offsets_rel: [dict] = list(map(lambda so: parse_special_pos(so, iso_enter_glyph_pos), profile['special-offsets'].items()))
     glyph_offsets = list(map(glyph_inf, glyph_files(glyph_dir)))
+    duplicate_glyphs:[str] = list(map(lambda c: c[1][0]['glyph'] + ' @ ' + ', '.join(list(map(lambda c2: c2['src'], c[1]))), get_dicts_with_duplicate_field_values(glyph_offsets, 'glyph').items()))
+    if duplicate_glyphs != []:
+        printw('Duplicate glyphs detected:\n\t' + '\n\t'.join(duplicate_glyphs))
+    exit(0)
     glyph_map = read_yaml(glyph_map_file)
     glyph_map_rel = list(
         map(lambda m: {

--- a/util.py
+++ b/util.py
@@ -157,3 +157,13 @@ def get_only(lst:[object]) -> object:
         die('Attempted to get "only" element in a list of size %d (expected exactly one element)' % len(lst))
     else:
         return lst[0]
+
+def get_dicts_with_duplicate_field_values(data:[dict], key:object) -> dict:
+    seens:dict = {}
+    for datum in data:
+        value:object = datum[key]
+        if value in seens:
+            seens[value].append(datum)
+        else:
+            seens[value] = [datum]
+    return { p:seens[p] for p in seens if len(seens[p]) > 1 }


### PR DESCRIPTION
### What's changed?

Check for duplicate keycaps and glyphs; warn user of present.
Previously this wasn't the case so it was possible to have multiple keycap models and glyphs at the same key location.

### Check lists

- [x] Compiled with Cython
