### PR TITLE
Generate Blender operators

### DIFF
--- a/adjustkeys_addon.py.in
+++ b/adjustkeys_addon.py.in
@@ -19,7 +19,7 @@ if 'bpy' in locals():
 
 from bpy.utils import register_class, unregister_class
 from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, PointerProperty, StringProperty
-from bpy.types import Panel, Operator, PropertyGroup, Scene
+from bpy.types import Context, Panel, Operator, PropertyGroup, Scene
 from inspect import getmembers
 from os.path import dirname
 from sys import path
@@ -43,6 +43,8 @@ def sanitise_choice_args(kv:tuple) -> tuple:
         v = v.lower().replace('_', '-')
     return (k,v)
 
+def get_args_from_ui(context:Context) -> dict:
+    return dict(map(sanitise_choice_args, filter(lambda m: m[0] in configurable_arg_dests, getmembers(context.scene.adjustkeys_custom_props))))
 
 class AdjustKeysOperator(Operator):
     bl_idname = 'object.adjustkeys'
@@ -50,9 +52,14 @@ class AdjustKeysOperator(Operator):
 
     def execute(self, context):
         self.report({'INFO'}, 'Adjustkeys is operating, might be a moments...')
-        akargs:dict = dict(map(sanitise_choice_args, filter(lambda m: m[0] in configurable_arg_dests, getmembers(context.scene.adjustkeys_custom_props))))
+        akargs:dict = get_args_from_ui(context)
         adjustkeys(akargs)
         return {'FINISHED'}
+
+KCZA_CUSTOM_OPERATORS
+
+generatedOperators:[dict] = [ KCZA_CUSTOM_OPERATOR_HEADERS ]
+generatedOperatorClasses:[type] = [ KCZA_CUSTOM_OPERATOR_TYPES ]
 
 class KCZA_PT_AdjustKeysPanel(Panel):
     ''''''
@@ -67,21 +74,28 @@ class KCZA_PT_AdjustKeysPanel(Panel):
         layout = self.layout
         col = layout.column()
         col.operator('object.adjustkeys', text='Place caps and glyphs', icon='MOD_MESHDEFORM')
+        for op in generatedOperators:
+            col.operator(op['idname'], text=op['label'], icon=op['icon'])
         for carg in configurable_args:
             row = layout.row()
             row.prop(context.scene.adjustkeys_custom_props, carg['dest'])
 
+classes:[type] = [
+    KCZA_PT_AdjustKeysPanel,
+    AdjustKeysOperator
+] + generatedOperatorClasses
+
 def register():
     register_class(KczaCustomPropertyGroup)
     Scene.adjustkeys_custom_props = PointerProperty(type=KczaCustomPropertyGroup)
-    register_class(KCZA_PT_AdjustKeysPanel)
-    register_class(AdjustKeysOperator)
+    for cls in classes:
+        register_class(cls)
 
 def unregister():
     unregister_class(KczaCustomPropertyGroup)
     del Scene.adjustkeys_custom_props
-    unregister_class(KCZA_PT_AdjustKeysPanel)
-    unregister_class(AdjustKeysOperator)
+    for cls in classes:
+        unregister_class(cls)
 
 if __name__ == '__main__':
     register()

--- a/args.py
+++ b/args.py
@@ -226,7 +226,9 @@ args: [dict] = [{
     'help': 'Output a list of known keycap names read form the input files',
     'default': False,
     'label': 'List keycap model names',
-    'type': bool
+    'type': bool,
+    'label': 'Print found keycap models',
+    'op': True
 }, {
     'dest': 'list_cap_names',
     'short': '-Sn',
@@ -235,7 +237,9 @@ args: [dict] = [{
     'help': 'Output a list of known keycap names read form the input files',
     'default': False,
     'label': 'List keycap mapping-names',
-    'type': bool
+    'type': bool,
+    'label': 'Print known keycap labels',
+    'op': True
 }, {
     'dest': 'list_glyphs',
     'short': '-Sg',
@@ -244,7 +248,9 @@ args: [dict] = [{
     'help': 'Output a list of known glyphs read from the input files',
     'default': False,
     'label': 'List found glyph names',
-    'type': bool
+    'type': bool,
+    'label': 'Print known glyph names',
+    'op': True
 }, {
     'dest': 'no_adjust_caps',
     'short': '-Nc',
@@ -331,7 +337,9 @@ args: [dict] = [{
     'action': 'store_true',
     'help': 'Print the current options values in the YAML format for configuration purposes and exit',
     'default': False,
-    'type': bool
+    'type': bool,
+    'label': 'Print opts.yml',
+    'op': True
 }, {
     'dest': 'profile_file',
     'short': '-C',
@@ -392,9 +400,11 @@ args: [dict] = [{
     'long': '--version',
     'action': 'version',
     'version': version,
-    'help': 'Show current version and exit',
+    'help': 'Print current version and exit',
     'default': False,
-    'type': bool
+    'type': bool,
+    'label': 'Print version',
+    'op': True
 }, {
     'dest': 'show_help',
     'short': '-h',
@@ -407,10 +417,11 @@ args: [dict] = [{
 
 arg_dict: dict = {a['dest']: a for a in args if 'dest' in a}
 configurable_args: [dict] = list(
-    sorted(filter(lambda a: 'dest' in a and 'label' in a, args),
+    sorted(filter(lambda a: 'dest' in a and 'label' in a and 'op' not in a, args),
            key=lambda a:
            ('choices' in a, str(a['type']), a['str-type']
             if 'str-type' in a else 'raw', a['label'])))
+op_args:[dict] = list(filter(lambda a: 'dest' in a and 'label' in a and 'op' in a and a['op'], args))
 
 home:str = Path.home()
 progname:str = 'adjustkeys'

--- a/propgen.py
+++ b/propgen.py
@@ -7,7 +7,7 @@ from util import rem
 
 def main() -> None:
     props:str = '\n    '.join(list(map(lambda a: a['dest'] + ':' + prop(a), configurable_args)))
-    ops:[dict] = list(sorted(map(op, op_args), key=lambda op: op['label']))
+    ops:[dict] = list(sorted(map(op, op_args), key=lambda op: (op['icon'], op['label'])))
     file:str = stdin.read()
 
     replacements:dict = {


### PR DESCRIPTION
### What's changed?

Previously there was no way to interact with the command flags (e.g. `--show-glyph-names`), but now UI buttons are automatically generated to allow access to these.
Output for these is given and highlighted in the system console.

### Check lists

- [x] Compiled with Cython
