### PR TITLE
Earlier bpy imports

### DIFF
--- a/adjustcaps.py
+++ b/adjustcaps.py
@@ -43,18 +43,6 @@ def adjust_caps(layout: [dict], pargs:Namespace) -> dict:
 
     colour_map:[dict] = read_yaml(pargs.colour_map_file)
 
-    #  printi('Adjusting and outputting caps on %d thread%s...' %(pargs.nprocs, 's' if pargs.nprocs != 1 else ''))
-    #  if pargs.nprocs == 1:
-        #  # Run as usual, seems to help with the error reporting because reasons
-        #  for cap in caps:
-            #  handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
-    #  else:
-        #  with ThreadPoolExecutor(pargs.nprocs) as ex:
-            #  cops: ['[dict,str]->()'] = [
-                #  ex.submit(handle_cap, cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
-                #  for cap in caps
-            #  ]
-            #  wait(cops)
     printi('Adjusting keycaps...')
     for cap in caps:
         handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)

--- a/adjustcaps.py
+++ b/adjustcaps.py
@@ -38,35 +38,26 @@ def main(*args: [[str]]) -> int:
 
 def adjust_caps(layout: [dict], pargs:Namespace) -> dict:
     # Resolve output unique output name
+    printi('Getting required keycap data...')
     caps: [dict] = get_data(layout, pargs.cap_dir, pargs.colour_map_file)
-
-    seen: dict = {}
-    printi('Resolving cap output names')
-    for cap in caps:
-        if cap['cap-name'] not in seen:
-            seen[cap['cap-name']] = 1
-        else:
-            seen[cap['cap-name']] += 1
-        cap['oname'] = join(
-            pargs.output_dir, pargs.output_prefix + '-' + cap['cap-name'] +
-            ('-' +
-             str(seen[cap['cap-name']]) if seen[cap['cap-name']] > 1 else '') +
-            '.obj')
 
     colour_map:[dict] = read_yaml(pargs.colour_map_file)
 
-    printi('Adjusting and outputting caps on %d thread%s...' %(pargs.nprocs, 's' if pargs.nprocs != 1 else ''))
-    if pargs.nprocs == 1:
-        # Run as usual, seems to help with the error reporting because reasons
-        for cap in caps:
-            handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
-    else:
-        with ThreadPoolExecutor(pargs.nprocs) as ex:
-            cops: ['[dict,str]->()'] = [
-                ex.submit(handle_cap, cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
-                for cap in caps
-            ]
-            wait(cops)
+    #  printi('Adjusting and outputting caps on %d thread%s...' %(pargs.nprocs, 's' if pargs.nprocs != 1 else ''))
+    #  if pargs.nprocs == 1:
+        #  # Run as usual, seems to help with the error reporting because reasons
+        #  for cap in caps:
+            #  handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
+    #  else:
+        #  with ThreadPoolExecutor(pargs.nprocs) as ex:
+            #  cops: ['[dict,str]->()'] = [
+                #  ex.submit(handle_cap, cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
+                #  for cap in caps
+            #  ]
+            #  wait(cops)
+    printi('Adjusting keycaps...')
+    for cap in caps:
+        handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
 
     # Sequentially import the models (for thread-safety)
     if blender_available():
@@ -78,36 +69,21 @@ def adjust_caps(layout: [dict], pargs:Namespace) -> dict:
             m['material'] = data.materials.new(name=m['name'])
             m['material'].diffuse_color = colour
 
-        objectsPreImport: [str] = data.objects.keys()
+        # Apply materials
+        printi('Applying material colourings...')
         for cap in caps:
-            printi('Importing "%s" into blender...' % cap['oname'])
-            objectsPreSingleImport:[str] = data.objects.keys()
-            ops.import_scene.obj(filepath=cap['oname'], axis_up='Z', axis_forward='Y')
-            objectsPostSingleImport:[str] = data.objects.keys()
-            cap['imported-name'] = get_only(list_diff(objectsPostSingleImport, objectsPreSingleImport), 'No new id was added when importing from %s' % cap['oname'], 'Multiple ids changed when importing %s, got %%d new: %%s' % cap['oname'])
-            cap['imported-object'] = context.scene.objects[cap['imported-name']]
-            printi(cap['imported-name'])
-            printi('Applying material to %s' % cap['oname'])
             if cap['cap-colour'] is not None:
                 if cap['cap-colour'] not in colourMaterials:
                     colourStr:str = cap['cap-colour']
                     colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
                     colourMaterials[colourStr] = { 'material': data.materials.new(name=cap['cap-colour']) }
                     colourMaterials[colourStr]['material'].diffuse_color = colour
-                cap['imported-object'].data.materials.append(colourMaterials[cap['cap-colour']]['material'])
-                cap['imported-object'].active_material = colourMaterials[cap['cap-colour']]['material']
-            printi('Deleting file "%s"' % cap['oname'])
-            remove(cap['oname'])
-        objectsPostImport: [str] = data.objects.keys()
-        importedCapObjectNames: [str] = list_diff(objectsPostImport,
-                                                  objectsPreImport)
-        importedCapObjects: [Object] = [
-            o for o in data.objects if o.name in importedCapObjectNames
-        ]
-        printi('Successfully imported keycap objects')
+                cap['cap-obj'].data.materials.append(colourMaterials[cap['cap-colour']]['material'])
+                cap['cap-obj'].active_material = colourMaterials[cap['cap-colour']]['material']
 
         importedModelName: str = None
-        if len(importedCapObjectNames) != 0:
+        importedCapObjects:[Object] = list(map(lambda cap: cap['cap-obj'], caps))
+        if len(importedCapObjects) != 0:
             printi('Joining keycap models into a single object')
             ctx: dict = context.copy()
 
@@ -138,6 +114,30 @@ def get_data(layout: [dict], cap_dir: str, colour_map_file:str) -> [dict]:
         printw('Duplicate keycap names detected:\n\t' + '\n\t'.join(duplicate_cap_names))
     layout_with_caps: [dict] = inner_join(caps, 'cap-name', layout, 'cap-name')
 
+    # Import necessary cap models
+    firsts:dict = {}
+    for cap_data in layout_with_caps:
+        if cap_data['cap-source'] not in firsts:
+            # Import new object
+            printi('Importing "%s" into blender...' % cap_data['cap-source'])
+            objectsPreSingleImport:[str] = data.objects.keys()
+            ops.import_scene.obj(filepath=cap_data['cap-source'], axis_up='Z', axis_forward='Y')
+            objectsPostSingleImport:[str] = data.objects.keys()
+            cap_data['cap-obj-name'] = get_only(list_diff(objectsPostSingleImport, objectsPreSingleImport), 'No new id was added when importing from %s' % cap_data['cap-source'], 'Multiple ids changed when importing %s, got %%d new: %%s' % cap_data['cap-source'])
+            cap_data['cap-obj'] = context.scene.objects[cap_data['cap-obj-name']]
+            firsts[cap_data['cap-source']] = cap_data['cap-obj']
+        else:
+            # Duplicate existing object
+            printi('Duplicating existing "%s"...' % cap_data['cap-source'])
+            objectsPreCopy:[str] = data.objects.keys()
+            original_obj = firsts[cap_data['cap-source']].copy()
+            objectsPostCopy:[str] = data.objects.keys()
+            cap_data['cap-obj-name'] = get_only(list_diff(objectsPostCopy, objectsPreCopy), 'No new id was added when copying from %s' % cap_data['cap-source'], 'Multiple ids changed when copying %s, got %%d new: %%s' % cap_data['cap-source'])
+            new_obj = original_obj.copy()
+            new_obj.data = original_obj.data.copy()
+            cap_data['cap-obj'] = new_obj
+            context.scene.collection.objects.link(new_obj)
+
     colour_map:[dict] = read_yaml(colour_map_file)
     layout_with_caps:[dict] = list(map(lambda cap: apply_colour(cap, colour_map), layout_with_caps))
 
@@ -150,6 +150,16 @@ def get_data(layout: [dict], cap_dir: str, colour_map_file:str) -> [dict]:
                '\n\t'.join(sorted(missing_models)))
 
     return layout_with_caps
+
+
+def handle_cap(cap: dict, unit_length: float, cap_x_offset: float,
+        cap_y_offset: float, colour_map:[dict]):
+    printi('Adjusting cap %s' % cap['cap-name'])
+    translate_to_origin(cap['cap-obj'])
+    cap = resolve_cap_position(cap, unit_length, cap_x_offset, cap_y_offset)
+    cap = apply_cap_position(cap)
+    printi('Resolving colour of cap %s' % cap['cap-name'])
+    cap = apply_colour(cap, colour_map)
 
 
 def apply_colour(cap:dict, colour_map:[dict]) -> dict:
@@ -165,33 +175,8 @@ def apply_colour(cap:dict, colour_map:[dict]) -> dict:
     return cap
 
 
-def de_spookify(cap: dict) -> dict:
-    return dict_union(rem(cap, 'cap-obj'),
-                      {'cap-obj': deepcopy(cap['cap-obj'])})
-
-
-def handle_cap(cap: dict, unit_length: float, cap_x_offset: float,
-        cap_y_offset: float):
-    printi('Adjusting cap %s' % cap['cap-name'])
-    cap = de_spookify(cap)
-    translate_to_origin(cap['cap-obj'])
-    cap = resolve_cap_position(cap, unit_length, cap_x_offset, cap_y_offset)
-    cap = apply_cap_position(cap)
-    printi('Resolving colour of cap %s' % cap['oname'])
-    printi('Outputting to "%s"' % cap['oname'])
-    write_obj(cap['oname'], cap['cap-obj'])
-
-
 def apply_cap_position(cap: dict) -> dict:
-    pos_x: float = cap['pos-x']
-    pos_y: float = cap['pos-y']
-    pos_z: float = cap['pos-z']
-    for _, _, _, gd in cap['cap-obj']:
-        for t, d in gd:
-            if t == 'v':
-                d[0] += pos_x
-                d[1] += pos_y
-                d[2] += pos_z
+    cap['cap-obj'].location = (cap['pos-x'], cap['pos-y'], cap['pos-z'])
     return cap
 
 
@@ -201,7 +186,6 @@ def get_caps(cap_dir: str) -> [dict]:
         map(lambda c: {
             'cap-name': basename(c)[:-4],
             'cap-source': c,
-            'cap-obj': read_obj(c)
         }, capFiles))
 
 

--- a/positions.py
+++ b/positions.py
@@ -2,6 +2,7 @@
 
 from log import printw
 from math import inf
+from mathutils import Matrix, Vector
 
 
 def resolve_glyph_positions(data: [dict], ulen: float, gx: float,
@@ -32,18 +33,6 @@ def resolve_cap_position(cap: dict, ulen: float, ox: float, oy: float) -> dict:
     return cap
 
 
-def translate_to_origin(data: [[str, [[str, list]]]]):
-    # Translate each group to the origin
-    for _, _, _, gd in data:
-        # Obtain minimum points in x, y and z
-        exts: [float] = [inf, -inf, inf]
-        funcs: ['[float,float] -> float'] = [min, max, min]
-        for t, d in gd:
-            if t == 'v':
-                for i in range(len(d)):
-                    exts[i] = funcs[i](exts[i], d[i])
-        # Translate by offset to origin
-        for t, d in gd:
-            if t == 'v':
-                for i in range(len(d)):
-                    d[i] -= exts[i]
+def translate_to_origin(cap_obj:object):
+    cap_obj.data.transform(Matrix.Translation(-Vector(cap_obj.bound_box[3])))
+    cap_obj.matrix_world.translation += Vector(cap_obj.bound_box[3])

--- a/shrink_wrap.py
+++ b/shrink_wrap.py
@@ -13,7 +13,7 @@ def shrink_wrap_glyphs_to_keys(glyph_names: [str], keycap_model_name: str,
     # Shrink-wrap glyphs onto the keycaps
     printi('Shrink-wrapping glyphs onto "%s"' % keycap_model_name)
     for glyph_name in glyph_names:
-        # Translate to favourable position (assuming no 3u tall keycaps
+        # Translate to favourable position (assuming no 3u tall keycaps)
         glyph:Obj = data.objects[glyph_name]
         glyph.location.z += 3.0 * cap_unit_length
 


### PR DESCRIPTION
### What's changed?

Previously a tonne of raw data was accessed in a slightly hacky way of getting the keycaps into the correct positions in order to make `adjustkeys` tool-agnostic.
Now, bpy is used much earlier allowing geometry-based methods to be used to alter model positions, which is _significantly_ faster, although this is at the cost of making `adjustkeys` more Blender-specific.

### Check lists

- [x] Compiled with Cython
