### PR TITLE
Blender as a Prerequisite

### DIFF
--- a/adjustcaps.py
+++ b/adjustcaps.py
@@ -31,6 +31,9 @@ def main(*args: [[str]]) -> int:
         printi('Making non-existent directory "%s"' % pargs.output_dir)
         makedirs(pargs.output_dir, exist_ok=True)
     layout = get_layout(pargs.layout_file, pargs.layout_row_profile_file, pargs.homing_keys)
+    if not blender_available():
+        die('bpy is not available, please run adjustcaps from within Blender (instructions should be in the supplied README.md file)')
+
     adjust_caps(layout, pargs)
 
     return 0
@@ -48,49 +51,46 @@ def adjust_caps(layout: [dict], pargs:Namespace) -> dict:
         handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset, colour_map)
 
     # Sequentially import the models (for thread-safety)
-    if blender_available():
-        printi('Preparing material')
-        colourMaterials:dict = { m['name'] : m for m in colour_map }
-        for m in colourMaterials.values():
-            colourStr:str = str(m['colour'])
-            colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
-            m['material'] = data.materials.new(name=m['name'])
-            m['material'].diffuse_color = colour
+    printi('Preparing material')
+    colourMaterials:dict = { m['name'] : m for m in colour_map }
+    for m in colourMaterials.values():
+        colourStr:str = str(m['colour'])
+        colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
+        m['material'] = data.materials.new(name=m['name'])
+        m['material'].diffuse_color = colour
 
-        # Apply materials
-        printi('Applying material colourings...')
-        for cap in caps:
-            if cap['cap-colour'] is not None:
-                if cap['cap-colour'] not in colourMaterials:
-                    colourStr:str = cap['cap-colour']
-                    colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
-                    colourMaterials[colourStr] = { 'material': data.materials.new(name=cap['cap-colour']) }
-                    colourMaterials[colourStr]['material'].diffuse_color = colour
-                cap['cap-obj'].data.materials.append(colourMaterials[cap['cap-colour']]['material'])
-                cap['cap-obj'].active_material = colourMaterials[cap['cap-colour']]['material']
+    # Apply materials
+    printi('Applying material colourings...')
+    for cap in caps:
+        if cap['cap-colour'] is not None:
+            if cap['cap-colour'] not in colourMaterials:
+                colourStr:str = cap['cap-colour']
+                colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
+                colourMaterials[colourStr] = { 'material': data.materials.new(name=cap['cap-colour']) }
+                colourMaterials[colourStr]['material'].diffuse_color = colour
+            cap['cap-obj'].data.materials.append(colourMaterials[cap['cap-colour']]['material'])
+            cap['cap-obj'].active_material = colourMaterials[cap['cap-colour']]['material']
 
-        importedModelName: str = None
-        importedCapObjects:[Object] = list(map(lambda cap: cap['cap-obj'], caps))
-        if len(importedCapObjects) != 0:
-            printi('Joining keycap models into a single object')
-            ctx: dict = context.copy()
+    importedModelName: str = None
+    importedCapObjects:[Object] = list(map(lambda cap: cap['cap-obj'], caps))
+    if len(importedCapObjects) != 0:
+        printi('Joining keycap models into a single object')
+        ctx: dict = context.copy()
 
-            ctx['object'] = ctx['active_object'] = importedCapObjects[0]
-            ctx['selected_objects'] = ctx[
-                'selected_editable_objects'] = importedCapObjects
-            ops.object.join(ctx)
+        ctx['object'] = ctx['active_object'] = importedCapObjects[0]
+        ctx['selected_objects'] = ctx[
+            'selected_editable_objects'] = importedCapObjects
+        ops.object.join(ctx)
 
-            printi('Renaming keycap model')
-            objectsPreRename: [str] = data.objects.keys()
-            importedCapObjects[0].name = importedCapObjects[
-                0].data.name = 'capmodel'
-            objectsPostRename: [str] = data.objects.keys()
-            importedModelName = get_only(
-                    list_diff(objectsPostRename, objectsPreRename), 'No new id was created by blender when renaming the keycap model', 'Multiple new ids were created when renaming the keycap model (%d new): %s')
-            printi('Keycap model renamed to "%s"' % importedModelName)
-        return { 'keycap-model-name': importedModelName, 'material-names': list(colourMaterials.keys()) }
-    else:
-        return {}
+        printi('Renaming keycap model')
+        objectsPreRename: [str] = data.objects.keys()
+        importedCapObjects[0].name = importedCapObjects[
+            0].data.name = 'capmodel'
+        objectsPostRename: [str] = data.objects.keys()
+        importedModelName = get_only(
+                list_diff(objectsPostRename, objectsPreRename), 'No new id was created by blender when renaming the keycap model', 'Multiple new ids were created when renaming the keycap model (%d new): %s')
+        printi('Keycap model renamed to "%s"' % importedModelName)
+    return { 'keycap-model-name': importedModelName, 'material-names': list(colourMaterials.keys()) }
 
 
 def get_data(layout: [dict], cap_dir: str, colour_map_file:str) -> [dict]:

--- a/adjustcaps.py
+++ b/adjustcaps.py
@@ -45,7 +45,7 @@ def adjust_caps(layout: [dict], pargs:Namespace) -> dict:
 
     printi('Adjusting keycaps...')
     for cap in caps:
-        handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset)
+        handle_cap(cap, pargs.cap_unit_length, pargs.cap_x_offset, pargs.cap_y_offset, colour_map)
 
     # Sequentially import the models (for thread-safety)
     if blender_available():

--- a/adjustglyphs.py
+++ b/adjustglyphs.py
@@ -33,6 +33,9 @@ def main(*args: [str]) -> int:
     init_logging(pargs.verbosity)
 
     layout = get_layout(pargs.layout_file, pargs.layout_row_profile_file, pargs.homing_keys)
+    if not blender_available():
+        die('bpy is not available, please run adjustcaps from within Blender (instructions should be in the supplied README.md file)')
+
     svgObjNames: [str] = adjust_glyphs(layout, pargs)
 
     return 0
@@ -76,25 +79,25 @@ def adjust_glyphs(layout:[dict], pargs:Namespace) -> [str]:
     svgObjectNames: str = None
     with open(output_location, 'w+') as f:
         print(svg, file=f)
-    if blender_available():
-        printi('Importing svg into blender')
-        objectsPreImport: [str] = data.objects.keys()
-        ops.import_curve.svg(filepath=output_location)
-        objectsPostImport: [str] = data.objects.keys()
 
-        # Rename the svg
-        svgObjectNames = list_diff(objectsPostImport, objectsPreImport)
+    printi('Importing svg into blender')
+    objectsPreImport: [str] = data.objects.keys()
+    ops.import_curve.svg(filepath=output_location)
+    objectsPostImport: [str] = data.objects.keys()
 
-        # Apprpriately scale the objects
-        printi('Scaling glyphs')
-        for svgObjectName in svgObjectNames:
-            data.objects[svgObjectName].scale *= scale
+    # Rename the svg
+    svgObjectNames = list_diff(objectsPostImport, objectsPreImport)
 
-        # Clean output
-        if exists(output_location):
-            printi('Deleting file "%s"' % output_location)
-            remove(output_location)
-        printi('Successfully imported svg objects')
+    # Apprpriately scale the objects
+    printi('Scaling glyphs')
+    for svgObjectName in svgObjectNames:
+        data.objects[svgObjectName].scale *= scale
+
+    # Clean output
+    if exists(output_location):
+        printi('Deleting file "%s"' % output_location)
+        remove(output_location)
+    printi('Successfully imported svg objects')
 
     return { 'glyph-names': svgObjectNames } if svgObjectNames is not None else {}
 

--- a/adjustkeys.py
+++ b/adjustkeys.py
@@ -85,7 +85,7 @@ def adjustkeys(*args: [[str]]) -> dict:
         glyph_data = adjust_glyphs(layout, pargs)
 
     # If blender is loaded, shrink-wrap the glyphs onto the model
-    if not pargs.no_shrink_wrap and not pargs.no_adjust_caps and not pargs.no_adjust_glyphs and blender_available():
+    if not pargs.no_shrink_wrap and not pargs.no_adjust_caps and not pargs.no_adjust_glyphs:
         shrink_wrap_glyphs_to_keys(glyph_data['glyph-names'], model_data['keycap-model-name'], pargs.cap_unit_length, pargs.shrink_wrap_offset)
 
     return dict_union(model_data, glyph_data)

--- a/adjustkeys.py
+++ b/adjustkeys.py
@@ -11,7 +11,7 @@ from args import parse_args, Namespace
 from exceptions import AdjustKeysException, AdjustKeysGracefulExit
 from glyphinf import glyph_name
 from layout import get_layout, parse_layout
-from log import init_logging, printi, printw
+from log import die, init_logging, printi, printw
 from os import makedirs
 from os.path import exists
 from scale import get_scale
@@ -65,12 +65,14 @@ def adjustkeys(*args: [[str]]) -> dict:
         print('\n'.join(list(map(lambda kc: kc[0] + ' @ ' + kc[1], knownCaps))))
         return 0
 
+    layout:[dict] = get_layout(pargs.layout_file, pargs.layout_row_profile_file, pargs.homing_keys)
+
+    if not blender_available():
+        die('bpy is not available, please run `adjustkeys` from within Blender (instructions should be in the supplied README.md file)')
 
     if not exists(pargs.output_dir):
         printi('Making non-existent directory "%s"' % pargs.output_dir)
         makedirs(pargs.output_dir, exist_ok=True)
-
-    layout:[dict] = get_layout(pargs.layout_file, pargs.layout_row_profile_file, pargs.homing_keys)
 
     # Adjust model positions
     model_data:dict = {}

--- a/args.py
+++ b/args.py
@@ -2,8 +2,6 @@
 
 from argparse import ArgumentParser, Namespace
 from blender_available import blender_available
-if blender_available():
-    from bpy import data
 from exceptions import AdjustKeysGracefulExit
 from log import die
 from functools import reduce


### PR DESCRIPTION
### What's changed?

Previously, Blender was only a 'soft'-dependency---if it was not loaded, later parts of the program were not executed.
However, this came at the cost of performance as noted in #25.
Therefore, Blender is now a formal prerequisite to the execution of any significant part of `adjustkeys`, that is, any part which is not simply printing out configuration data.

### Check lists

- [x] Compiled with Cython
