### PR TITLE
Options yaml file handling from the UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ adjustkeys-bin: $(ADJUST_KEYS_SRCS)
 	chmod 700 $@
 
 examples/opts.yml: opts-header.txt adjustkeys-bin
-	((cat && ./adjustkeys-bin '-#' && sed 's/^/# /') | sed 's/ $$//' | grep -v opt_file) < $< > $@
+	((sed 's/^/# /' && ./adjustkeys-bin '-#') | sed 's/ $$//' | grep -v opt_file | sed 's/print_opts_yml: true/print_opts_yml: false/') < $< > $@
 
 requirements.txt: $(ADJUST_KEYS_SRCS)
 	(pipreqs --force --print 2>/dev/null | grep -v bpy) > $@
@@ -101,5 +101,5 @@ opts-header.txt:
 
 
 clean:
-	$(RM) -r bin_*/ __pycache__/ bin/ *.c *.zip *.1.gz requirements.txt *.1 *.html ChangeLog.md examples/opts.yml adjust-keys.zip *.pdf $(wildcard profiles/**/centres.yml) adjust_keys_blender_addon/ adjustkeys/adjustkeys_addon.py
+	$(RM) -r bin_*/ __pycache__/ bin/ *.c *.zip *.1.gz requirements.txt *.1 *.html ChangeLog.md examples/opts.yml adjust-keys.zip *.pdf $(wildcard profiles/**/centres.yml) adjust_keys_blender_addon/ adjustkeys/adjustkeys_addon.py adjustkeys-bin
 .PHONY: clean

--- a/adjustkeys/adjustkeys_addon.py.in
+++ b/adjustkeys/adjustkeys_addon.py.in
@@ -20,7 +20,7 @@ bl_info = {
         'author': "Ed Jones",
         'version': VERSION,
         'blender': (2, 83, 0),
-        'location': 'Properties > Render Properties > Adjustkeys',
+        'location': 'Properties > Scene Properties > Adjustkeys',
         'description': 'Automatic keycap and glyph alignment tool',
         'warning': 'Adjustkeys is still in development so please play nice :P',
         'support': 'COMMUNITY',
@@ -42,11 +42,10 @@ from math import ceil, log10
 arg_dict = { a['dest']: a for a in configurable_args }
 configurable_arg_dests = list(map(lambda a: a['dest'], configurable_args))
 
-assert all(map(lambda a: 'help' in a, configurable_args))
-
 class KczaCustomPropertyGroup(PropertyGroup):
-    # If you're seening CUSTOM_PROPERTIES just here, it gets replaced by propgen.py when building
+    # If you're seening CUSTOM_PROPERTIES just here, it gets replaced by propgen when building
     KCZA_CUSTOM_PROPERTIES
+
 
 def sanitise_choice_args(kv:tuple) -> tuple:
     (k,v) = kv
@@ -65,11 +64,15 @@ class AdjustKeysOperator(Operator):
     def execute(self, context):
         self.report({'INFO'}, 'Adjustkeys is operating, might be a moments...')
         akargs = get_args_from_ui(context)
+        if akargs['opt_file'] != 'None':
+            akargs = { 'opt_file': akargs['opt_file'] }
+        print(akargs)
         adjustkeys(akargs)
         return {'FINISHED'}
 
 KCZA_CUSTOM_OPERATORS
 
+# If you're seeing CUSTOM_OPERATOR_* things, note that they get replaced by propgen when building
 generatedOperators = [ KCZA_CUSTOM_OPERATOR_HEADERS ]
 generatedOperatorClasses = [ KCZA_CUSTOM_OPERATOR_TYPES ]
 
@@ -78,9 +81,8 @@ class KCZA_PT_AdjustKeysPanel(Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_label = 'Adjustkeys'
-    bl_context = 'render'
+    bl_context = 'scene'
     bl_icon = 'MOD_MESHDEFORM'
-    #  bl_category = 'kcza'
 
     def draw(self, context):
         layout = self.layout
@@ -97,24 +99,13 @@ classes = [
     AdjustKeysOperator
 ] + generatedOperatorClasses
 
-from traceback import print_exc
-
 def register():
-    #  try:
-        #  register_module(__name__)
-        #  print('Registered %s with %d modules' % (bl_info['name'], len(modules)))
-    #  except:
-        #  print_exc()
     register_class(KczaCustomPropertyGroup)
     Scene.adjustkeys_custom_props = PointerProperty(type=KczaCustomPropertyGroup)
     for cls in classes:
         register_class(cls)
 
 def unregister():
-    #  try:
-        #  unregister_module(__name__)
-    #  except:
-        #  print_exc()
     unregister_class(KczaCustomPropertyGroup)
     del Scene.adjustkeys_custom_props
     for cls in classes:

--- a/adjustkeys/args.py
+++ b/adjustkeys/args.py
@@ -14,7 +14,6 @@ from functools import reduce
 from multiprocessing import cpu_count
 from os import getcwd
 from os.path import exists, join
-from pathlib import Path
 from platform import system
 if blender_available():
     data = LazyImport('bpy', 'data')
@@ -122,7 +121,7 @@ args: [dict] = [{
     'action': 'store',
     'help': 'specify the directory containing the svg glyphs',
     'metavar': 'file',
-    'default': adjustkeys_path,
+    'default': join(adjustkeys_path, 'examples'),
     'label': 'Glyph folder',
     'type': str,
     'str-type': 'dir'
@@ -284,11 +283,12 @@ args: [dict] = [{
     'long': '--args',
     'action': 'store',
     'help':
-    'specify a YAML option file to be take read initial argument values from',
+    'specify a YAML option file to read initial argument values from',
     'metavar': 'file',
     'default': None,
     'type': str,
-    'str-type': 'file'
+    'str-type': 'file',
+    'label': 'YAML option file'
 }, {
     'dest': 'output_dir',
     'short': '-o',
@@ -394,9 +394,7 @@ configurable_args: [dict] = list(
             if 'str-type' in a else 'raw', a['label'])))
 op_args:[dict] = list(filter(lambda a: 'dest' in a and 'label' in a and 'op' in a and a['op'], args))
 
-home:str = Path.home()
 progname:str = 'adjustkeys'
-install_dir:str = { 'Linux': join(home, '.local', 'lib', 'adjustkeys'), 'Windows': join(home, 'Library', 'Application Support', 'Adjustkeys'), 'Darwin': join(home, 'AppData', 'Local', 'Adjustkeys') }[system()]
 
 ##
 # @brief Parse commandline arguments
@@ -427,10 +425,12 @@ def parse_args(iargs: tuple) -> Namespace:
         pargs = iargs
     else:
         pargs: dict = ap.parse_args(iargs[1:]).__dict__
+    if 'opt_file' not in pargs or pargs['opt_file'] is None:
+        pargs['opt_file'] = 'None'
 
     # Obtain yaml arguments
     yargs: dict = {}
-    if 'opt_file' in pargs and pargs['opt_file'] is not None:
+    if pargs['opt_file'] != 'None':
         if exists(pargs['opt_file']):
             yargs = read_yaml(pargs['opt_file'])
         else:

--- a/propgen
+++ b/propgen
@@ -49,6 +49,7 @@ def prop(a:dict) -> str:
         maxval:float = a['max']
         return f"IntProperty(name={label}, description={description}, default={default}, min={minval}, max={maxval})"
     elif atype == str:
+        default = "d if ((d := %s) is not None) else 'None'" % default
         if 'str-type' in a:
             str_type:str = a['str-type']
             if str_type == 'file':


### PR DESCRIPTION
### What's changed?

Previously, there was no handling for YAML options files from the UI.
Now, if an options file is specified, that is, the argument is not `'None'`, then the appropriate file is found and all UI options are then ignored.

### Check lists

- [x] Compiled with Cython
