### PR TITLE
Move keycap model origin to global origin

### DIFF
--- a/adjustkeys/positions.py
+++ b/adjustkeys/positions.py
@@ -33,6 +33,6 @@ def resolve_cap_position(cap: dict, ulen: float, ox: float, oy: float) -> dict:
     return cap
 
 
-def translate_to_origin(cap_obj:object):
-    cap_obj.data.transform(Matrix.Translation(-Vector(cap_obj.bound_box[3])))
-    cap_obj.matrix_world.translation += Vector(cap_obj.bound_box[3])
+def move_object_origin_to_global_origin(obj:object):
+    obj.data.transform(Matrix.Translation(-Vector(obj.bound_box[3])))
+    obj.matrix_world.translation += Vector(obj.bound_box[3])


### PR DESCRIPTION
### What's changed?

Previously, the keycap model origin was attached to an apparently-random keycap after placement.
Now, it is set to the global origin, which should make the midel a little easier to manipulate.

At time of writing, the glyphs' origin is close to the origin (always 3u above it in the Z direction), so these could use similar treatment but this is not urgent.

### Check lists

- [x] Compiled with Cython
