### PR TITLE
Warnings output on exit

### DIFF
--- a/adjustkeys/adjustcaps.py
+++ b/adjustkeys/adjustcaps.py
@@ -6,7 +6,7 @@ from .args import parse_args
 from .blender_available import blender_available
 from .layout import get_layout, parse_layout
 from .lazy_import import LazyImport
-from .log import die, init_logging, printi, printw
+from .log import die, init_logging, printi, printw, print_warnings
 from .obj_io import read_obj, write_obj
 from .path import walk
 from .positions import move_object_origin_to_global_origin, resolve_cap_position
@@ -38,6 +38,8 @@ def main(*args: [[str]]) -> int:
         die('bpy is not available, please run adjustcaps from within Blender (instructions should be in the supplied README.md file)')
 
     adjust_caps(layout, pargs)
+
+    print_warnings()
 
     return 0
 

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -6,7 +6,7 @@ from .blender_available import blender_available
 from .glyphinf import glyph_inf
 from .layout import get_layout, parse_layout
 from .lazy_import import LazyImport
-from .log import die, init_logging, printi, printw
+from .log import die, init_logging, printi, printw, print_warnings
 from .path import walk
 from .positions import resolve_glyph_positions
 from .scale import get_scale
@@ -38,6 +38,8 @@ def main(*args: [str]) -> int:
         die('bpy is not available, please run adjustcaps from within Blender (instructions should be in the supplied README.md file)')
 
     svgObjNames: [str] = adjust_glyphs(layout, pargs)
+
+    print_warnings()
 
     return 0
 

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -11,7 +11,7 @@ from .blender_available import blender_available
 from .exceptions import AdjustKeysException, AdjustKeysGracefulExit
 from .glyphinf import glyph_name
 from .layout import get_layout, parse_layout
-from .log import die, init_logging, printi, printw
+from .log import die, init_logging, printi, printw, print_warnings
 from .scale import get_scale
 from .shrink_wrap import shrink_wrap_glyphs_to_keys
 from .update_checker import update_available
@@ -28,6 +28,8 @@ def main(*args:[[str]]) -> dict:
         return adjustkeys(args)
     except AdjustKeysGracefulExit:
         return 0
+    finally:
+        print_warnings()
 
 def adjustkeys(*args: [[str]]) -> dict:
     pargs: Namespace = parse_args(args)
@@ -88,12 +90,15 @@ def adjustkeys(*args: [[str]]) -> dict:
     return dict_union(model_data, glyph_data)
 
 if __name__ == '__main__':
+    rc:int = 0
+    err:Exception = None
     try:
-        exit(adjustkeys(argv) is None)
+        rc = adjustkeys(argv) is None
     except KeyboardInterrupt:
-        exit(1)
+        rc = 1
     except AdjustKeysGracefulExit:
-        exit(0)
+        rc = 0
     except AdjustKeysException as akex:
         print(argv[0] + ':', akex)
-        exit(1)
+        rc = 1
+    exit(rc)

--- a/adjustkeys/args.py
+++ b/adjustkeys/args.py
@@ -371,7 +371,7 @@ args: [dict] = [{
     'action': 'store',
     'help': 'Output verbosely',
     'metavar': 'int',
-    'default': 0,
+    'default': 1,
     'type': int,
     'choices': [0, 1, 2]
 }, {

--- a/adjustkeys/log.py
+++ b/adjustkeys/log.py
@@ -4,6 +4,7 @@ from .exceptions import AdjustKeysException
 from sys import argv, stderr
 
 verbosity: int = 0
+warnings:[[tuple,dict]] = []
 
 
 ##
@@ -17,6 +18,14 @@ def init_logging(verbosity_in: bool):
     global verbosity
     verbosity = verbosity_in
 
+
+##
+# @brief Print all of the stored warnings
+#
+# @return Nothing
+def print_warnings():
+    for args,kwargs in warnings:
+        print(*args, file=stderr, **kwargs)
 
 ##
 # @brief Write a message to stderr and raise an exception
@@ -61,4 +70,4 @@ def printe(*args, **kwargs):
 # @return Nothing
 def printw(*args, **kwargs):
     if verbosity >= 1:
-        print(f'{argv[0]}: WARNING:', *args, file=stderr, **kwargs)
+        warnings.append(([f'{argv[0]}: WARNING:'] + list(args), kwargs))


### PR DESCRIPTION
### What's changed?

Previously, warnings were output when they were detected, but this led to their being lost under the huge amount of un-suppressible Blender IO logging.
Now, all warnings are stored until the end of the execution of the main body (i.e. once all the work has been done) so that the user can more clearly see them.

### Check lists

- [x] Compiled with Cython
