### PR TITLE
ISO enter left margin fix

### DIFF
--- a/adjustkeys/layout.py
+++ b/adjustkeys/layout.py
@@ -79,14 +79,15 @@ def parse_key(key: 'either str dict',
 
     if 'key-type' not in ret:
         ret_key: str = safe_get(ret, 'key')
-        if safe_get(ret, 'x') == 0.25 \
-            and safe_get(ret, 'a') == 7 \
+        x_in:float = safe_get(ret, 'x')
+        if x_in is not None and x_in >= 0.25 \
             and safe_get(ret, 'w') == 1.25 \
             and safe_get(ret, 'h') == 2 \
             and safe_get(ret, 'w2') == 1.5 \
             and safe_get(ret, 'h2') == 1 \
             and safe_get(ret, 'x2') == -0.25:
             ret['key-type'] = 'iso-enter'
+            ret['x'] -= 0.25
         elif ret_key == '+' and safe_get(ret, 'h') == 2:
             ret['key-type'] = 'num-plus'
         elif ret_key and ret_key.lower() == 'enter' and safe_get(ret,


### PR DESCRIPTION
### What's changed?

Previously, a 0.25 left margin was applied by erroneously reading KLE’s representation of the ISO enter which places multiple boxes in the same position.
This was misread by the layout handler to imply a 0.25 gap to the left of the keycap, but in fact this is due to the KLE representation placing a 1.25x2u box to represent the vertical part of the keycap, with the 0.25u margin being used to create the over-hang and thus forming a part of the cap.
Now, if an ISO-enter key is detected, this extra 0.25 is removed from it’s left margin (`x` input field) to place the cap correctly.

### Check lists

- [x] Compiled with Cython
