### PR TITLE
Improve installation process for Windows users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ examples/opts.yml: opts-header.txt adjustkeys-bin
 	((sed 's/^/# /' && ./adjustkeys-bin '-#') | sed 's/ $$//' | grep -v opt_file | sed 's/print_opts_yml: true/print_opts_yml: false/') < $< > $@
 
 requirements.txt: $(ADJUST_KEYS_SRCS)
-	(pipreqs --force --print 2>/dev/null | grep -v bpy) > $@
+	@# Assumes that Blender is already installed and has mathutils available
+	(pipreqs --force --print 2>/dev/null | grep -v bpy | grep -v mathutils) > $@
 
 ChangeLog.md: change-log.sh change-log-format.awk
 	./$< > $@

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Therefore, `adjustkeys` exists—to help banish the duplication of tedious align
 
 ## Usage
 
-You’ll need a working installation of Blender, [`python3`][python] and its package manager, [`pip3`][pip] (these probably came with Blender) and a little familiarity with the YAML syntax (although this can be picked up as, it’s designed to be relatively human-friendly).
+You’ll need a working installation of Blender (v2.8x or v2.9x work), [`python3`][python] and its package manager, [`pip3`][pip] (these probably came with Blender) and a little familiarity with the YAML syntax (although this can be picked up as, it’s designed to be relatively human-friendly).
 There’s two ways of interacting with `adjustkeys`, either through the Blender extension or through Python.
 
 ### Usage Through a Blender Addon (Regular)


### PR DESCRIPTION
### What's changed?

Previously, it was assumed that the `mathutils` package would need to be installed through the dependency-handling process.
Now, it is assumed (quite weakly) that Blender will ship with `mathutils` and hence this does not need to be present in the `requirements.txt` generated, thus removing an annoying Microsoft Visual C++ install dependency, which was a pain for Windows users (Linux and macOS already coming with a C++ distribution natively).

### Check lists

- [x] Compiled with Cython
