### PR TITLE
Verbosity GUI control

### DIFF
--- a/addongen
+++ b/addongen
@@ -37,14 +37,22 @@ def prop(a:dict) -> str:
     label:str = '"' + a['label'] + '"'
     description:str = '"' + a['help'] + '"'
     dest:str = a['dest']
-    default = "arg_dict['%s']['default']" % dest
+    default:object = "arg_dict['%s']['default']" % dest
     if 'choices' in a:
         choices:[[str, str, str, int]] = []
         rawChoices = a['choices']
         for i in range(len(rawChoices)):
             choice = rawChoices[i]
-            choices.append((choice.upper().replace('-', '_'), choice.title(), '', i))
-        default = default + ".upper().replace('-', '_')"
+            formattedChoice:[object,str,str,int]
+            if atype == str:
+                formattedChoice = (choice.upper().replace('-', '_'), choice.title(), '', i)
+            else:
+                formattedChoice = (str(choice), str(choice), '', i)
+            choices.append(formattedChoice)
+        if atype == str:
+            default = default + ".upper().replace('-', '_')"
+        else:
+            defailt = str(default)
         return f'EnumProperty(items={choices}, name={label}, default={default}, description={description})'
     elif atype == bool:
         return f"BoolProperty(name={label}, description={description}, default={default})"

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -353,9 +353,10 @@ args: [dict] = [{
     'short': '-v',
     'long': '--verbose',
     'action': 'store',
-    'help': 'Output verbosely',
+    'help': 'Control how much logging output is given, 0 for minimal, 2 for everything',
     'metavar': 'int',
     'default': 1,
+    'label': 'Console-output verbosity',
     'type': int,
     'choices': [0, 1, 2]
 }, {


### PR DESCRIPTION
### What's changed?

Previously, verbose output was only configurable manually through python or the CLI.
Now, a property has been added to the addon to allow the user to more easily control this setting and see what’s going on behind the scenes.

### Check lists

- [x] Compiled with Cython
