### PR TITLE
KLE colour deserialisation fix

### DIFF
--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -156,7 +156,7 @@ def get_style(key:dict) -> str:
         raw_style:str = key['glyph-style']
         if match('^[0-9a-f]{6}$', key['glyph-style'], IGNORECASE) is not None:
             # Apply RGB colour
-            style = 'style="fill:#%s;"' % raw_style.upper()
+            style = 'style="fill:#%s;"' % raw_style
         else:
             # Otherwise assume CSS has been written
             if not raw_style.endswith(';'):

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -76,7 +76,7 @@ def adjustkeys(*args: [[str]]) -> dict:
         printi('Making non-existent directory "%s"' % pargs.output_dir)
         makedirs(pargs.output_dir, exist_ok=True)
 
-    layout:[dict] = get_layout(pargs.layout_file, pargs.layout_row_profile_file, pargs.homing_keys)
+    layout:[dict] = get_layout(pargs.layout_file, pargs.layout_row_profile_file, pargs.homing_keys, not pargs.no_apply_colour_map)
     colour_map:[dict] = read_yaml(pargs.colour_map_file) if not pargs.no_apply_colour_map else None
     coloured_layout:[dict] = colourise_layout(layout, colour_map)
 

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -4,18 +4,28 @@ from re import IGNORECASE, match
 
 def colourise_layout(layout:[dict], colour_map:[dict]) -> [dict]:
     for key in layout:
-        apply_colouring(key, colour_map, 'cap-colour', 'cap-colour-raw', 'name')
-        apply_colouring(key, colour_map, 'glyph-style', 'glyph-colour-raw', 'glyph-style')
+        apply_sanitised_colouring(key, colour_map, 'cap-colour', 'cap-colour-raw', 'name')
+        apply_sanitised_colouring(key, colour_map, 'glyph-style', 'glyph-colour-raw', 'glyph-style')
     return layout
 
-def apply_colouring(key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str):
-    if raw_key in key:
-        key[target_key] = key[raw_key]
+def apply_sanitised_colouring(key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str):
+    key[target_key] = sanitise_colour(get_colouring(key, colour_map, target_key, raw_key, extraction_key))
+
+def get_colouring(key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str) -> str:
+    if raw_key in key and key[raw_key] is not None:
+        return key[raw_key]
     else:
         if colour_map is not None:
             key_name = key['key']
             for mapping in colour_map:
                 if target_key in mapping and any(map(lambda r: match('^' + r + '$', key_name, IGNORECASE) is not None, mapping['keys'])):
-                    key[target_key] = mapping[extraction_key]
-                    return
-        key[target_key] = None
+                    return mapping[extraction_key]
+        return None
+
+def sanitise_colour(colour_str:str) -> str:
+    if colour_str is None:
+        return None
+
+    if colour_str[0] == '#':
+        colour_str = colour_str[1:]
+    return colour_str


### PR DESCRIPTION
### What's changed?

Previously, the KLE input colour was only applied to the keycap where it was declared.
Now, it is held as a state and is applied to all subsequent caps.
If a colour-map is used, then if the KLE colour specified for a given keycap is equal to the default colour, this is taken as an indication to fallback to the colour-map, otherwise it is taken as a valid colour.

For example, the default glyph colour is `#000000`.
If `#000000` is seen when a colour-map is not used then it is applied to the keycap’s glyph like any other colour.
Otherwise, if the colour-map is used, then it indicates that the colour specified by the colour map should be used, until otherwise specified.

### Check lists

- [x] Compiled with Cython
