### PR TITLE
Group generated objects

### DIFF
--- a/adjustkeys/collections.py
+++ b/adjustkeys/collections.py
@@ -1,0 +1,17 @@
+# Copyright (C) Edward Jones
+
+from .blender_available import blender_available
+Collection:type = None
+if blender_available():
+    from bpy import context, data
+    from bpy.types import Collection
+
+def make_collection(collection_intended_name:str) -> Collection:
+    i:int = 0
+    col_name:str = collection_intended_name
+    while col_name in data.collections:
+        i += 1
+        col_name = collection_intended_name + '-' + str(i)
+    collection:Collection = data.collections.new(col_name)
+    context.scene.collection.children.link(collection)
+    return collection

--- a/adjustkeys/util.py
+++ b/adjustkeys/util.py
@@ -76,12 +76,19 @@ def inner_join(las: [dict],
 ##
 # @brief Output the union of a pair of dictionaries
 #
-# @param a:dict A dictionary
-# @param b:dict Another dictionary
+# @param ds:dict A dictionary
 #
 # @return The union of `a` and `b`, where a key is present in both, the value from `b` is used
-def dict_union(a: dict, b: dict) -> dict:
-    return dict(a, **b)
+##
+# @brief Output the unoin of a list of dictionaries
+#
+# @param *ds:[dict] A list of dictionaries
+#
+# @return The union of all ds
+def dict_union(*ds:[dict]) -> dict:
+    def _dict_union(a:dict, b:dict) -> dict:
+        return dict(a, **b)
+    return dict(reduce(_dict_union, ds, {}))
 
 
 ##


### PR DESCRIPTION
### What's changed?

Previously, generated objects were placed haphazardly in the collection tree.
Now, all objects generated by a particular run of adjustkeys are placed into the same collection.

### Check lists

- [x] Compiled with Cython
