### PR TITLE
Fix replication issue

### DIFF
--- a/adjustkeys/adjustcaps.py
+++ b/adjustkeys/adjustcaps.py
@@ -74,8 +74,12 @@ def adjust_caps(layout: [dict], colour_map:[dict], profile_data:dict, collection
 
         printi('Renaming keycap model')
         objectsPreRename: [str] = data.objects.keys()
-        importedCapObjects[0].name = importedCapObjects[
-            0].data.name = 'capmodel'
+        intended_name:str = 'capmodel'
+        i:int = 1
+        while intended_name in data.objects:
+            i += 1
+            intended_name = 'capmodel' + '-' + str(i)
+        importedCapObjects[0].name = importedCapObjects[0].data.name = intended_name
         objectsPostRename: [str] = data.objects.keys()
         importedModelName = get_only(
                 list_diff(objectsPostRename, objectsPreRename), 'No new id was created by blender when renaming the keycap model', 'Multiple new ids were created when renaming the keycap model (%d new): %s')

--- a/adjustkeys/collections.py
+++ b/adjustkeys/collections.py
@@ -6,12 +6,14 @@ if blender_available():
     from bpy import context, data
     from bpy.types import Collection
 
-def make_collection(collection_intended_name:str) -> Collection:
-    i:int = 0
+def make_collection(collection_intended_name:str, parent_collection:Collection=None) -> Collection:
+    if parent_collection is None:
+        parent_collection = context.scene.collection
+    i:int = 1
     col_name:str = collection_intended_name
     while col_name in data.collections:
         i += 1
         col_name = collection_intended_name + '-' + str(i)
     collection:Collection = data.collections.new(col_name)
-    context.scene.collection.children.link(collection)
+    parent_collection.children.link(collection)
     return collection


### PR DESCRIPTION
### What's changed?

Previously, separate runs of `adjustkeys` within the same instance of Blender would interact as added objects were automatically renamed, causing problems such as broken shrink-wrapping and glyphs disappearing.
Now, all objects to be added into blender are renamed to ensure uniqueness, allowing for multiple keyboard models to be present in the same blender instance.

### Check lists

- [x] Compiled with Cython
