### PR TITLE
Minor intuition improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,11 @@ The [licensing section](#author-and-acknowledgements) section below should be up
 I wrote this in Python for two reasons:
 
 1. There exists a large, well-documented Python API for Blender
-2. ~~So that anyone learning to program could have an example of some reasonably complicated code and some reasonably clean methods to deal with challenges~~ This is some of the most unmaintainable code I’ve written in a decent while, please if anyone’s out there, look upon this work as the kind of mess which can arise when records aren’t a proper part of the type system and take note of the silly security measures which are required when a language allows module-imports to have side-effects.
+2. ~~So that anyone learning to program could have an example of some reasonably complicated code and some reasonably clean methods to deal with challenges~~ Python is a popular but bad programming language.
 
-Of course, using Python was really annoying due to it’s basically useless type system and its failure to report errors ahead of time which made development a pain as usual.
-My sanity would have been better-off had I instead done this in [Haskell][haskell], but I guess everyone has their regrets, eh?
+Some languages like C are beautifully simple, others like [Haskell][haskell] are beautifully complex, but alas Python is neither.
+It’s type system (“duck typing”), it’s lack of native support for type annotations is bad, its import system caching when it can’t find packages is bad and that imported modules are allowed to have side-effects is bad.
+Although Python isn’t the only language to suffer these ailments, it’s the only one I’ve seen which lies at the intersection of all these problems and is also popular.
 
 ## Author and Acknowledgements
 

--- a/adjustkeys/adjustkeys_addon.py.in
+++ b/adjustkeys/adjustkeys_addon.py.in
@@ -41,6 +41,14 @@ configurable_arg_dests = list(map(lambda a: a['dest'], configurable_args))
 Dependency = namedtuple('Dependency', ['module', 'package', 'name'])
 
 dependencies = [ DEPENDENCY_LIST ]
+dependencyWarningLines = [
+        "If you’re seeing this, it means that adjustkeys is missing some dependencies. Before installing these, you should note the following.",
+        "Firstly, an internet connection will be used to download the necessary packages.",
+        "Secondly, depending on the your setup, you may need to run Blender with elevated privileges. This is not advisable in the general case, so please don’t do this if you don’t need to.",
+        "The following dependencies (and their dependencies) are required:"
+    ] + list(map(lambda d: '∙ %s' % d.package, sorted(dependencies, key=lambda d: d.package.lower()))) + [
+        "To install these dependencies, press the button below and this message should disappear. DO NOT QUIT BLENDER WHILE DEPENDENCIES ARE INSTALLING as the side-effects of this action are undefined. Open the system console to see what’s happening behind the scenes."
+    ]
 
 class KczaCustomPropertyGroup(PropertyGroup):
     # If you're seening CUSTOM_PROPERTIES just here, it gets replaced by addongen when building
@@ -135,6 +143,7 @@ class KCZA_PT_DependencyWarningPanel(Panel):
     bl_label = 'Adjustkeys'
     bl_region_type = 'WINDOW'
     bl_space_type = 'PROPERTIES'
+    message_width = 50
 
     @classmethod
     def poll(self, context):
@@ -143,15 +152,7 @@ class KCZA_PT_DependencyWarningPanel(Panel):
     def draw(self, context):
         from .adjustkeys.util import dumb_wrap_text
         layout = self.layout
-        warningLines = [
-                "If you’re seeing this, it means that adjustkeys is missing some dependencies. Before asking your permission to install these, you should note the following.",
-                "Firstly, an internet connection will be used to download the necessary packages.",
-                "Secondly, depending on the your setup, you may need to run Blender with elevated privileges. This is not advisable in the general case, so please don’t do this if you don’t need to.",
-                "The following dependencies are required:"
-            ] + list(map(lambda d: '∙ %s' % d.package, sorted(dependencies, key=lambda d: d.package.lower()))) + [
-                "To install these dependencies, press the button below and this message should disappear. DO NOT QUIT BLENDER WHILE DEPENDENCIES ARE INSTALLING as the side-effects of this action are undefined. Look at the system console to see what’s happening behind the scenes."
-            ]
-        for line in dumb_wrap_text(warningLines, 50):
+        for line in dumb_wrap_text(dependencyWarningLines, self.message_width):
             layout.label(text=line)
         layout.operator(KCZA_OT_InstallDependencies.bl_idname, icon='CONSOLE')
 
@@ -163,16 +164,11 @@ class KCZA_Preferences(AddonPreferences):
         from .adjustkeys.util import dumb_wrap_text
         layout = self.layout
         if not dependencies_installed:
-            updateMessageText = [
-                    'Dependency status: some missing',
-                    'For more details and how to fix this, in the main window, please see Preferences > Scene Preferences > Adjustkeys.'
-                ]
-            for line in dumb_wrap_text(updateMessageText, self.message_width):
+            for line in dumb_wrap_text(dependencyWarningLines, self.message_width):
                 layout.label(text=line)
+            layout.operator(KCZA_OT_InstallDependencies.bl_idname, icon='CONSOLE')
         else:
-            messageText = [
-                    'Dependency status: OK'
-                ]
+            messageText = [ 'Dependency status: OK' ]
             for line in dumb_wrap_text(messageText, self.message_width):
                 layout.label(text=line)
 


### PR DESCRIPTION
- Unified dependency install message, added install button back into addon preferences
- Reworded gripes section a little

### What's changed?

Previously the dependency install message was unintuitive for new users, containing a couple of typos and lacking a dependency-install button.
Now, the dependency-install button has been reinstateed there and the same message is used in the preferences as in the warning panel.
Also there were some minor grammar changes to the readme.

### Check lists

- [x] Compiled with Cython
