### PR TITLE
Preserve the profile in KLE layout if empty given

### DIFF
--- a/adjustkeys/input_types.py
+++ b/adjustkeys/input_types.py
@@ -95,7 +95,7 @@ def type_check_kle_layout(kl:object) -> [[bool, bool]]:
                                 elif k in ['l', 'n', 'd', 'g']:
                                     (okay, _) = assert_type(okay, v, bool, 'Key %s must be either true/false, for %s' %(k, str(v)))
                                 elif k == 'p':
-                                    (okay, _) = assert_cond(okay, v in ['R1', 'R2', 'R3', 'R4', 'R5', 'SPACE'], 'Adjustkeys only recognises profiles R1-5 and SPACE, got value %s for p-key' % str(v))
+                                    (okay, _) = assert_cond(okay, v in ['R1', 'R2', 'R3', 'R4', 'R5', 'SPACE', '', None], 'Adjustkeys only recognises profiles R1-5 and SPACE, got value %s for p-key' % str(v))
                                 else:
                                     (okay, _) = assert_cond(okay, type(v) in [float, int], 'Expected either an integer, or a number with a decimal point for key %s, got %s' %(k, str(v)))
     return okay

--- a/adjustkeys/layout.py
+++ b/adjustkeys/layout.py
@@ -181,7 +181,7 @@ def parse_key(key: 'either str dict', nextKey: 'maybe (either str dict)', parser
         ret = key_subst(ret, 'l', 'stepped')
     else:
         ret['stepped'] = False
-    if 'p' in ret:
+    if 'p' in ret and ret['p']:
         ret = key_subst(ret, 'p', 'profile-part')
     else:
         ret['profile-part'] = parser_state.p


### PR DESCRIPTION
### What's changed?

In KLE, if the profile specified is the same as that in the current state, an empty string is used in the `p` field.
This was not previously handled, but now if either the empty string or null (to aid YAML readability) is specified for the profile, the parser state’s current profile is no longer (incorrectly) updated.

### Check lists

- [x] Compiled with Cython
