### PR TITLE
EnumProperty default value fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Therefore, `adjustkeys` exists—to help banish the duplication of tedious align
 
 ## Usage
 
-You’ll need a working installation of [Blender][blender] (v2.8x or v2.9x work) and a little familiarity with the [yaml][yaml-intro] syntax (although this can be picked up as it’s designed to be relatively human-friendly).
+You’ll need a working installation of [Blender][blender] (v2.82+ or v2.90+ work) and a little familiarity with the [yaml][yaml-intro] syntax (although this can be picked up as it’s designed to be relatively human-friendly).
 There’s two ways of interacting with `adjustkeys`, either through the Blender extension or through Python, both are explained here.
 
 **Important**: currently, you need to be able to view the console output for certain features of `adjustkeys`, which can be done as follows depending on your operating system.

--- a/addongen
+++ b/addongen
@@ -52,7 +52,7 @@ def prop(a:dict) -> str:
         if atype == str:
             default = default + ".upper().replace('-', '_')"
         else:
-            defailt = str(default)
+            default = 'str(%s)' % default
         return f'EnumProperty(items={choices}, name={label}, default={default}, description={description})'
     elif atype == bool:
         return f"BoolProperty(name={label}, description={description}, default={default})"


### PR DESCRIPTION
### What's changed?

Previous versions of Blender (pre 2.90) require that the default value of an `EnumProperty` be a string, but this has been relaxed and as such, the extension was not compatible with older Blender versions.
The string convention is now adhered to and the extension has been successfully tested on Blender versions 2.82–2.90.

### Check lists

- [x] Compiled with Cython
