### PR TITLE
Apply subsurf modifier to glyph-part

### DIFF
--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -109,7 +109,13 @@ def adjustkeys(*args: [[str]]) -> dict:
 
     # If blender is loaded, shrink-wrap the glyphs onto the model
     if not pargs.no_shrink_wrap and not pargs.no_adjust_caps and not pargs.no_adjust_glyphs:
-        shrink_wrap_glyphs_to_keys(glyph_data['glyph-names'], model_data['keycap-model-name'], profile_data['unit-length'], pargs.shrink_wrap_offset, profile_data['scale'] * pargs.scaling)
+        subsurf_params:dict = {
+                'viewport-levels': pargs.subsurf_viewport_levels,
+                'render-levels': pargs.subsurf_render_levels,
+                'quality': pargs.subsurf_quality,
+                'adaptive-subsurf': pargs.adaptive_subsurf
+            }
+        shrink_wrap_glyphs_to_keys(glyph_data['glyph-names'], model_data['keycap-model-name'], profile_data['unit-length'], pargs.shrink_wrap_offset, subsurf_params, profile_data['scale'] * pargs.scaling)
 
     return dict_union(collection_data, model_data, glyph_data)
 

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -6,6 +6,15 @@ from os.path import join
 
 default_opts_file: str = 'opts.yml'
 args: [dict] = [{
+    'dest': 'adaptive_subsurf',
+    'short': '-Fa',
+    'long': '--adaptive-subsurf',
+    'action': 'store_true',
+    'help': 'Apply adaptively apply subdivision surface modifiers to the glyphs-parts by using size to determine how many levels to use. Each glyph part has a number of subdivisions applied in the range [0...m], where m is (by context) either the max viewport or render subdivision level values',
+    'default': False,
+    'type': bool,
+    'label': 'Adaptively apply subsurf modifiers',
+}, {
     'dest': 'alignment',
     'short': '-a',
     'long': '--alignment',
@@ -254,6 +263,42 @@ args: [dict] = [{
     'type': float,
     'soft-min': 0.0,
     'soft-max': 1.0,
+}, {
+    'dest': 'subsurf_viewport_levels',
+    'short': '-Fv',
+    'long': '--subsurf-viewport-levels',
+    'action': 'store',
+    'help': 'Set the levels of the subdivision surface modifier applied ot glyph parts in the viewport',
+    'metavar': 'levels',
+    'default': 2,
+    'label': 'Subsurf mod viewport levels',
+    'type': int,
+    'min': 0,
+    'max': 11
+}, {
+    'dest': 'subsurf_render_levels',
+    'short': '-Fr',
+    'long': '--subsurf-render-levels',
+    'action': 'store',
+    'help': 'Set the levels of the subdivision surface modifier applied ot glyph parts in renders',
+    'metavar': 'levels',
+    'default': 3,
+    'label': 'Subsurf mod render levels',
+    'type': int,
+    'min': 0,
+    'max': 11
+}, {
+    'dest': 'subsurf_quality',
+    'short': '-Fq',
+    'long': '--subsurf-quality',
+    'action': 'store',
+    'help': 'Set the quality parameter of the subdivision surface modifier applied to all glyph-parts',
+    'metavar': 'quality',
+    'default': 2,
+    'label': 'Subsurf mod quality',
+    'type': int,
+    'min': 0,
+    'max': 10
 }, {
     'dest': 'svg_units_per_mm',
     'short': '-D',

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -294,7 +294,7 @@ args: [dict] = [{
     'action': 'store',
     'help': 'Set the quality parameter of the subdivision surface modifier applied to all glyph-parts',
     'metavar': 'quality',
-    'default': 2,
+    'default': 3,
     'label': 'Subsurf mod quality',
     'type': int,
     'min': 0,

--- a/adjustkeys/shrink_wrap.py
+++ b/adjustkeys/shrink_wrap.py
@@ -2,6 +2,8 @@
 
 from .blender_available import blender_available
 from .lazy_import import LazyImport
+from .util import dict_union
+from math import log
 if blender_available():
     from bpy import types
     data = LazyImport('bpy', 'data')
@@ -11,24 +13,52 @@ from .log import printi, printw
 
 def shrink_wrap_glyphs_to_keys(glyph_names: [str], keycap_model_name: str,
                                cap_unit_length: float,
-                               shrink_wrap_offset: float, scaling:float) -> None:
+                               shrink_wrap_offset: float, subsurf_params:dict, scaling:float) -> None:
     if keycap_model_name is None:
         printw('Shrink-wrapping was aborted as no models were successfully imported into blender')
         return
 
-    # Shrink-wrap glyphs onto the keycaps
-    printi('Shrink-wrapping glyphs onto "%s"' % keycap_model_name)
-    for glyph_name in glyph_names:
-        # Translate to favourable position (assuming no 3u tall keycaps)
-        glyph:Obj = data.objects[glyph_name]
-        glyph.location.z += 3.0 * cap_unit_length * scaling
+    glyphs:[dict] = map(lambda gn: { 'obj': data.objects[gn] }, glyph_names)
+    min_log_max_dim:float = 0.0
+    max_log_max_dim:float = 0.0
+    if subsurf_params['adaptive-subsurf']:
+        glyphs = list(map(lambda g: dict_union(g, { 'log-max-dim': log(max(g['obj'].dimensions)) }), glyphs))
+        if len(glyphs) != 0:
+            min_log_max_dim = min(map(lambda g: g['log-max-dim'], glyphs))
+            max_log_max_dim = max(map(lambda g: g['log-max-dim'], glyphs))
+        else:
+            min_log_max_dim = 0.0
+            max_log_max_dim = 1.0
+    print(min_log_max_dim, max_log_max_dim)
 
-        #  # Shrink wrap glyph onto keycaps
-        modName: str = 'shrink_wrap_' + glyph.name
-        mod: ShrinkWrapModifier = glyph.modifiers.new(
-            name=modName, type='SHRINKWRAP')
-        mod.target = data.objects[keycap_model_name]
-        mod.wrap_method = 'PROJECT'
-        mod.use_project_z = True
-        mod.use_negative_direction = True
-        mod.offset = shrink_wrap_offset
+    # Shrink-wrap glyphs onto the keycaps
+    for glyph in glyphs:
+        # Translate to favourable position (assuming no 3u tall keycaps)
+        obj:Obj = glyph['obj']
+        obj.location.z += 3.0 * cap_unit_length * scaling
+
+        # Apply subdivision surface to glyph
+        printi('A%spplying subdivision surface to "%s"' %('daptively a' if subsurf_params['adaptive-subsurf'] else '', obj.name))
+        subsurfModName: str = 'subsurf_' + obj.name
+        subsurfMod: SubsurfModifier = obj.modifiers.new(name=subsurfModName, type='SUBSURF')
+        subsurfMod.quality = subsurf_params['quality']
+        subsurfMod.subdivision_type = 'SIMPLE'
+        if subsurf_params['adaptive-subsurf']:
+            subsurfMod.levels = round((glyph['log-max-dim'] - min_log_max_dim) / (max_log_max_dim - min_log_max_dim) * subsurf_params['viewport-levels'])
+            subsurfMod.render_levels = round((glyph['log-max-dim'] - min_log_max_dim) / (max_log_max_dim - min_log_max_dim) * subsurf_params['render-levels'])
+            #  subsurfMod.levels = subsurf_params['viewport-levels']
+            #  subsurfMod.render_levels = subsurf_params['render-levels']
+        else:
+            subsurfMod.levels = subsurf_params['viewport-levels']
+            subsurfMod.render_levels = subsurf_params['render-levels']
+
+        # Shrink wrap glyph onto keycaps
+        printi('Shrink-wrapping glyph-part "%s" onto "%s"' %(obj.name, keycap_model_name))
+        shrinkWrapModName: str = 'shrink_wrap_' + obj.name
+        shrinkWrapMod: ShrinkWrapModifier = obj.modifiers.new(
+            name=shrinkWrapModName, type='SHRINKWRAP')
+        shrinkWrapMod.target = data.objects[keycap_model_name]
+        shrinkWrapMod.wrap_method = 'PROJECT'
+        shrinkWrapMod.use_project_z = True
+        shrinkWrapMod.use_negative_direction = True
+        shrinkWrapMod.offset = shrink_wrap_offset


### PR DESCRIPTION
### What's changed?

Previously, glyph-parts imported into blender would be haphazardly shrink-wrapped to glyphs according to the number of vertices their curves were given.
Now, the user is able to specify a level of subdivision surface modifier to be applied to the glyphs.

There is also an _adaptive_ subsurf modifier option which for each glyph scales the value of `log(max(glyph.dimensions))` to the range `[0..m]` where `m` is the maximum viewport/render levels specified by the user.
This ensures that larger glyphs can appropriately be subdivided more, and that tiny ones are not subdivided to absurd levels.
(E.g. an ANSI-enter long arrow being subdivided the same number of times as a back-tick.)

### Check lists

- [x] Compiled with Cython
