### PR TITLE
More intuitive boolean parameters

### DIFF
--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -238,7 +238,9 @@ def get_glyph_vector_data(glyph:dict, style:str) -> [str]:
         ]
     if 'rotation' in glyph:
         transformations.append('rotate(%f)' % -degrees(glyph['rotation']))
-    header_content:[str] = [ 'transform="%s"' % ' '.join(transformations), style ]
+    header_content:[str] = [ 'transform="%s"' % ' '.join(transformations) ]
+    if style:
+        header_content.append(style)
 
     # Prepare svg content
     svg_content:[str] = list(map(lambda c: c.toxml(), map(sanitise_ids, filter(lambda c: type(c) == Element, glyph['svg'].childNodes))))

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -55,7 +55,7 @@ def adjustkeys(*args: [[str]]) -> dict:
             list(sorted(set(
                 map(
                     lambda k: k['key'],
-                    parse_layout(read_yaml(pargs.layout_file), not pargs.no_apply_colour_map)))))))
+                    parse_layout(read_yaml(pargs.layout_file), pargs.apply_colour_map)))))))
         return {}
     if pargs.list_glyphs:
         knownGlyphs:[[str,str]] = list(map(lambda g: [glyph_name(g), g], glyph_files(pargs.glyph_dir)))
@@ -76,19 +76,20 @@ def adjustkeys(*args: [[str]]) -> dict:
         die('bpy is not available, please run `adjustkeys` from within Blender (instructions should be in the supplied README.md file)')
 
     layout:[dict] = []
-    if not pargs.no_adjust_glyphs and not pargs.no_adjust_caps:
-        layout:[dict] = get_layout(pargs.layout_file, not pargs.no_apply_colour_map)
+    if pargs.adjust_glyphs or pargs.adjust_caps:
+        layout:[dict] = get_layout(pargs.layout_file, pargs.apply_colour_map)
     colour_map:[dict] = []
-    if not pargs.no_adjust_glyphs and not pargs.no_adjust_caps:
-        colour_map:[dict] = read_yaml(pargs.colour_map_file) if not pargs.no_apply_colour_map else None
-        if not type_check_colour_map(colour_map):
+    if pargs.adjust_glyphs or pargs.adjust_caps:
+        colour_map:[dict] = read_yaml(pargs.colour_map_file) if pargs.apply_colour_map else None
+        if pargs.apply_colour_map and not type_check_colour_map(colour_map):
             die('Colour map failed type-checking, see console for more information')
     coloured_layout:[dict] = colourise_layout(layout, colour_map)
-    if not pargs.no_adjust_glyphs and not pargs.no_adjust_caps:
-        profile_data:dict = read_yaml(join(pargs.cap_dir, 'profile_data.yml'))
+    profile_data:dict
+    if pargs.adjust_glyphs or pargs.adjust_caps:
+        profile_data = read_yaml(join(pargs.cap_dir, 'profile_data.yml'))
         if not type_check_profile_data(profile_data):
             die('Profile data failed type-checking, see console for more information')
-    if not pargs.no_adjust_glyphs:
+    if pargs.adjust_glyphs:
         glyph_map = read_yaml(pargs.glyph_map_file)
         if not type_check_glyph_map(glyph_map):
             die('Glyph map failed type-checking see the console for more information')
@@ -99,16 +100,16 @@ def adjustkeys(*args: [[str]]) -> dict:
 
     # Adjust model positions
     model_data:dict = {}
-    if not pargs.no_adjust_caps:
-        model_data = adjust_caps(layout, colour_map, profile_data, collection, pargs)
+    if pargs.adjust_caps:
+        model_data = adjust_caps(coloured_layout, colour_map, profile_data, collection, pargs)
 
     # Adjust glyph positions
     glyph_data:dict = {}
-    if not pargs.no_adjust_glyphs:
-        glyph_data = adjust_glyphs(layout, profile_data, collection, glyph_map, pargs)
+    if pargs.adjust_glyphs:
+        glyph_data = adjust_glyphs(coloured_layout, profile_data, collection, glyph_map, pargs)
 
     # If blender is loaded, shrink-wrap the glyphs onto the model
-    if not pargs.no_shrink_wrap and not pargs.no_adjust_caps and not pargs.no_adjust_glyphs:
+    if pargs.shrink_wrap and pargs.adjust_caps and pargs.adjust_glyphs:
         subsurf_params:dict = {
                 'viewport-levels': pargs.subsurf_viewport_levels,
                 'render-levels': pargs.subsurf_render_levels,

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -10,7 +10,7 @@ args: [dict] = [{
     'short': '-Fn',
     'long': '--no-adaptive-subsurf',
     'action': 'store_false',
-    'help': 'Apply adaptively apply subdivision surface modifiers to the glyphs-parts by using size to determine how many levels to use. Each glyph part has a number of subdivisions applied in the range [0...m], where m is (by context) either the max viewport or render subdivision level values',
+    'help': 'Adaptively apply subdivision surface modifiers to the glyphs-parts by using size to determine the number of levels. Each glyph part has a number of subdivisions applied in the range [0...m], where m is (by context) either the max viewport or render subdivision level values',
     'default': True,
     'type': bool,
     'label': 'Adaptively apply subsurf modifiers',
@@ -186,7 +186,7 @@ args: [dict] = [{
     'short': '-Nc',
     'long': '--no-adjust-caps',
     'action': 'store_false',
-    'help': "Don't perform cap adjustment",
+    'help': 'Import keycap models and correctly adjust their positions',
     'default': True,
     'label': 'Import keycap meshes',
     'type': bool
@@ -195,7 +195,7 @@ args: [dict] = [{
     'short': '-Ng',
     'long': '--no-adjust-glyphs',
     'action': 'store_false',
-    'help': "Don't perform glyph adjustment",
+    'help': 'Import glyphs and correctly adjust their positions',
     'default': True,
     'label': 'Import glyph curves',
     'type': bool
@@ -204,7 +204,7 @@ args: [dict] = [{
     'short': '-NC',
     'long': '--no-apply-colour_map',
     'action': 'store_false',
-    'help': "Don't apply colour materials to the keycaps (colouring in KLE layout file will still override this)",
+    'help': 'Apply the colour map file’s rules to the keycaps and glyphs (colouring in KLE layout file still overrides this)',
     'default': True,
     'label': 'Apply colour map',
     'type': bool
@@ -213,7 +213,7 @@ args: [dict] = [{
     'short': '-Ns',
     'long': '--no-shrink-wrap',
     'action': 'store_false',
-    'help': "Don't shrink wrap the adjusted glyphs and to the adjusted caps",
+    'help': "Subdivide and shrink wrap glyph models onto the keycaps",
     'default': True,
     'label': 'Shrink wrap glyphs to keys',
     'type': bool

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -7,11 +7,11 @@ from os.path import join
 default_opts_file: str = 'opts.yml'
 args: [dict] = [{
     'dest': 'adaptive_subsurf',
-    'short': '-Fa',
-    'long': '--adaptive-subsurf',
-    'action': 'store_true',
+    'short': '-Fn',
+    'long': '--no-adaptive-subsurf',
+    'action': 'store_false',
     'help': 'Apply adaptively apply subdivision surface modifiers to the glyphs-parts by using size to determine how many levels to use. Each glyph part has a number of subdivisions applied in the range [0...m], where m is (by context) either the max viewport or render subdivision level values',
-    'default': False,
+    'default': True,
     'type': bool,
     'label': 'Adaptively apply subsurf modifiers',
 }, {
@@ -182,40 +182,40 @@ args: [dict] = [{
     'type': bool,
     'op': True
 }, {
-    'dest': 'no_adjust_caps',
+    'dest': 'adjust_caps',
     'short': '-Nc',
     'long': '--no-adjust-caps',
-    'action': 'store_true',
+    'action': 'store_false',
     'help': "Don't perform cap adjustment",
-    'default': False,
-    'label': "Don't produce aligned keycaps",
+    'default': True,
+    'label': 'Import keycap meshes',
     'type': bool
 }, {
-    'dest': 'no_adjust_glyphs',
+    'dest': 'adjust_glyphs',
     'short': '-Ng',
     'long': '--no-adjust-glyphs',
-    'action': 'store_true',
+    'action': 'store_false',
     'help': "Don't perform glyph adjustment",
-    'default': False,
-    'label': "Don't produce aligned glyphs",
+    'default': True,
+    'label': 'Import glyph curves',
     'type': bool
 }, {
-    'dest': 'no_apply_colour_map',
+    'dest': 'apply_colour_map',
     'short': '-NC',
     'long': '--no-apply-colour_map',
-    'action': 'store',
+    'action': 'store_false',
     'help': "Don't apply colour materials to the keycaps (colouring in KLE layout file will still override this)",
-    'default': False,
-    'label': "Don't apply the colour map",
+    'default': True,
+    'label': 'Apply colour map',
     'type': bool
 }, {
-    'dest': 'no_shrink_wrap',
+    'dest': 'shrink_wrap',
     'short': '-Ns',
     'long': '--no-shrink-wrap',
-    'action': 'store_true',
+    'action': 'store_false',
     'help': "Don't shrink wrap the adjusted glyphs and to the adjusted caps",
-    'default': False,
-    'label': "Don't shrink-wrap glyphs onto keys",
+    'default': True,
+    'label': 'Shrink wrap glyphs to keys',
     'type': bool
 }, {
     'dest': 'opt_file',

--- a/adjustkeys/shrink_wrap.py
+++ b/adjustkeys/shrink_wrap.py
@@ -29,7 +29,6 @@ def shrink_wrap_glyphs_to_keys(glyph_names: [str], keycap_model_name: str,
         else:
             min_log_max_dim = 0.0
             max_log_max_dim = 1.0
-    print(min_log_max_dim, max_log_max_dim)
 
     # Shrink-wrap glyphs onto the keycaps
     for glyph in glyphs:


### PR DESCRIPTION
### What's changed?

Previously, the word ‘not’ appeared in many of the names of the boolean parameters, which obfuscated logic, especially for the user.
Not, the relevant parameters have been replaced with their negations to allow for more intuitive use of Blender’s UI controls; CLI parameters remain unchanged.

### Check lists

- [ ] Compiled with Cython
