### PR TITLE
Remove redundant `Show version` operation from blender UI

### DIFF
--- a/adjustkeys/adjustkeys_addon.py.in
+++ b/adjustkeys/adjustkeys_addon.py.in
@@ -21,7 +21,7 @@ bl_info = {
         'blender': (2, 82, 0),
         'location': 'Properties > Scene Properties > Adjustkeys',
         'description': 'Automatic keycap and glyph alignment tool',
-        'warning': 'Adjustkeys requires some python dependencies. It’s also new so please play nice :P',
+        'warning': 'Adjustkeys is quite new so please play nice :P',
         'support': 'COMMUNITY',
         'category': 'Import-Export',
         'tracker_url': 'https://github.com/TheSignPainter98/adjust-keys/issues',

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -332,8 +332,6 @@ args: [dict] = [{
     'help': 'Print current version and exit',
     'default': False,
     'type': bool,
-    'label': 'Show version',
-    'op': True
 }, {
     'dest': 'show_help',
     'short': '-h',


### PR DESCRIPTION
### What's changed?

The `Show version` button on the UI is redundant as the information is already shown when the extension is installed, and it is not an operation the user is likely to often require.
This button has been removed, but the command-line flag remains.

### Check lists

- [x] Compiled with Cython
