### PR TITLE
Object parenting

### DIFF
--- a/adjustkeys/adjustcaps.py
+++ b/adjustkeys/adjustcaps.py
@@ -120,7 +120,6 @@ def get_data(layout: [dict], cap_dir: str, colour_map:[dict], collection:Collect
             cap_data['cap-obj-name'] = get_only(list_diff(objectsPostSingleImport, objectsPreSingleImport), 'No new id was added when importing from %s' % cap_data['cap-source'], 'Multiple ids changed when importing %s, got %%d new: %%s' % cap_data['cap-source'])
             cap_data['cap-obj'] = context.scene.objects[cap_data['cap-obj-name']]
             firsts[cap_data['cap-source']] = cap_data['cap-obj']
-            collection.objects.link(cap_data['cap-obj'])
         else:
             # Duplicate existing object
             printi('Duplicating existing "%s"...' % cap_data['cap-source'])

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -79,10 +79,8 @@ def adjust_glyphs(layout:[dict], profile_data:dict, collection:Collection, glyph
     collectionName:str = get_only(list_diff(collectionsPostImport, collectionsPreImport), 'No collections added when importing glyphs', 'Multiple collections added whilst importing glyphs, got %d: %s')
 
     printi('Adding svg into the right collection')
-    glyph_collection = make_collection('glyphs', parent_collection=collection)
-    #  collection.children.link(glyph_collection)
     for svgObjectName in svgObjectNames:
-        glyph_collection.objects.link(data.objects[svgObjectName])
+        collection.objects.link(data.objects[svgObjectName])
     data.collections.remove(data.collections[collectionName])
 
     # Apprpriately scale the objects

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -78,13 +78,13 @@ def adjust_glyphs(layout:[dict], profile_data:dict, collection:Collection, glyph
     svgObjectNames:[str] = list_diff(objectsPostImport, objectsPreImport)
     collectionName:str = get_only(list_diff(collectionsPostImport, collectionsPreImport), 'No collections added when importing glyphs', 'Multiple collections added whilst importing glyphs, got %d: %s')
 
-    printi('Adding svg into the right collection')
+    printi("Adding svg into the correct collection")
     for svgObjectName in svgObjectNames:
         collection.objects.link(data.objects[svgObjectName])
     data.collections.remove(data.collections[collectionName])
 
     # Apprpriately scale the objects
-    printi('Scaling glyphs and moving origins')
+    printi('Scaling glyphs')
     for svgObjectName in svgObjectNames:
         data.objects[svgObjectName].scale *= scale * profile_data['scale'] * pargs.scaling
 

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -6,11 +6,11 @@ from .adjustglyphs import adjust_glyphs, glyph_files
 from .args import parse_args, Namespace
 from .blender_available import blender_available
 from .colour_resolver import colourise_layout
-from .collections import make_collection
 from .exceptions import AdjustKeysException, AdjustKeysGracefulExit
 from .glyphinf import glyph_name
 from .input_types import type_check_colour_map, type_check_glyph_map, type_check_profile_data
 from .layout import get_layout, parse_layout
+from .lazy_import import LazyImport
 from .log import die, init_logging, printi, printw, print_warnings
 from .scale import get_scale
 from .shrink_wrap import shrink_wrap_glyphs_to_keys
@@ -23,6 +23,7 @@ from sys import argv, exit
 from yaml import dump
 if blender_available():
     from bpy.types import Collection
+    context = LazyImport('bpy', 'context')
 
 
 def main(*args:[[str]]) -> dict:
@@ -94,9 +95,9 @@ def adjustkeys(*args: [[str]]) -> dict:
         if not type_check_glyph_map(glyph_map):
             die('Glyph map failed type-checking see the console for more information')
 
-    # Make the collection
-    collection:Collection = make_collection('adjustkeys_caps_and_glyphs')
-    collection_data:dict = { 'containing_collection': collection }
+    # Make collection
+    collection:Collection = context.collection
+    collection_data:dict = { 'containing-collection': collection }
 
     # Adjust model positions
     model_data:dict = {}

--- a/adjustkeys/shrink_wrap.py
+++ b/adjustkeys/shrink_wrap.py
@@ -4,6 +4,7 @@ from .blender_available import blender_available
 from .lazy_import import LazyImport
 from .util import dict_union
 from math import log
+from mathutils import Matrix
 if blender_available():
     from bpy import types
     data = LazyImport('bpy', 'data')
@@ -35,6 +36,10 @@ def shrink_wrap_glyphs_to_keys(glyph_names: [str], keycap_model_name: str,
         # Translate to favourable position (assuming no 3u tall keycaps)
         obj:Obj = glyph['obj']
         obj.location.z += 3.0 * cap_unit_length * scaling
+
+        printi('Setting parent of glyph "%s" to "%s"' % (obj.name, keycap_model_name))
+        obj.parent = data.objects[keycap_model_name]
+        obj.matrix_parent_inverse = obj.parent.matrix_world.inverted()
 
         # Apply subdivision surface to glyph
         printi('A%spplying subdivision surface to "%s"' %('daptively a' if subsurf_params['adaptive-subsurf'] else '', obj.name))


### PR DESCRIPTION
- Parent glyphs-parts to the keycap model for easier manipulation
- Fix paranting from different collection issue
- No longer makes collections, all new cap and glyph objects parented correctly

### What's changed?

Previously, glyphs and caps were placed into a new collection, however the action of a user changing their pose was slightly arcane and could be prone to user-error.
Not, the old collection system has been entirely removed and all glyphs are parented inside the keycap model for ease of use, while also making outliner panel much cleaner after execution of `adjustkeys`.

### Check lists

- [x] Compiled with Cython
