### PR TITLE
UV-wrapped glyphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ adjustedkeys*
 tags
 types_*.taghl
 *.blend
+capmodel*_uv_image.png

--- a/adjustkeys/adjustcaps.py
+++ b/adjustkeys/adjustcaps.py
@@ -26,6 +26,7 @@ from sys import argv, exit
 Collection:type = None
 if blender_available():
     from bpy import ops
+    from bpy.path import abspath
     from bpy.types import Collection
     data = LazyImport('bpy', 'data')
     context = LazyImport('bpy', 'context')
@@ -40,32 +41,26 @@ def adjust_caps(layout: [dict], colour_map:[dict], profile_data:dict, collection
     for cap in caps:
         handle_cap(cap, profile_data['unit-length'])
 
-    # Sequentially import the models
-    printi('Preparing materials')
-    colourMaterials:dict = {}
-    if colour_map is not None:
-        colourMaterials = { m['name'] : m for m in colour_map if 'cap-colour' in m }
-        for m in colourMaterials.values():
-            colourStr:str = str(m['cap-colour'])
-            colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
-            m['material'] = data.materials.new(name=m['name'])
-            m['material'].diffuse_color = colour
-
-    # Apply materials
-    printi('Applying material colourings...')
-    for cap in caps:
-        if cap['cap-colour'] is not None:
-            if cap['cap-colour'] not in colourMaterials:
-                colourStr:str = cap['cap-colour']
-                colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
-                colourMaterials[colourStr] = { 'material': data.materials.new(name=cap['cap-colour']) }
-                colourMaterials[colourStr]['material'].diffuse_color = colour
-            cap['cap-obj'].data.materials.append(colourMaterials[cap['cap-colour']]['material'])
-            cap['cap-obj'].active_material = colourMaterials[cap['cap-colour']]['material']
-
+    capmodel_name:str = generate_capmodel_name('capmodel')
+    uv_image_path:str = None
+    uv_material_name:str = None
+    colourMaterials:list = []
     importedModelName: str = None
     importedCapObjects:[Object] = list(map(lambda cap: cap['cap-obj'], caps))
+    imgNode:ShaderNodeTexImage = None
     if len(importedCapObjects) != 0:
+        # If shrink-wrapping, apply materials before the join
+        if pargs.glyph_application_method == 'shrinkwrap':
+            printi('Preparing individual materials')
+            colourMaterials = generate_shrink_wrap_materials(pargs.use_existing_materials, colour_map, caps)
+        else:
+            uv_image_path = abspath('//' + capmodel_name + '_uv_image.png')
+
+            printi('Handling material')
+            (imgNode, colourMaterials) = generate_uv_map_materials(pargs.use_existing_materials, uv_image_path, capmodel_name, caps)
+            if len(colourMaterials) != 0:
+                uv_material_name = colourMaterials[0]
+
         printi('Joining keycap models into a single object')
         ctx: dict = {}
         joinTarget:Object = min(caps, key=lambda c: (c['cap-pos'].x, c['cap-pos'].y))['cap-obj']
@@ -76,12 +71,7 @@ def adjust_caps(layout: [dict], colour_map:[dict], profile_data:dict, collection
 
         printi('Renaming keycap model')
         objectsPreRename: [str] = data.objects.keys()
-        intended_name:str = 'capmodel'
-        i:int = 1
-        while intended_name in data.objects:
-            i += 1
-            intended_name = 'capmodel' + '-' + str(i)
-        joinTarget.name = joinTarget.data.name = intended_name
+        joinTarget.name = joinTarget.data.name = capmodel_name
         objectsPostRename: [str] = data.objects.keys()
         importedModelName = get_only(
                 list_diff(objectsPostRename, objectsPreRename), 'No new id was created by blender when renaming the keycap model', 'Multiple new ids were created when renaming the keycap model (%d new): %s')
@@ -106,7 +96,75 @@ def adjust_caps(layout: [dict], colour_map:[dict], profile_data:dict, collection
             printi('UV-unwrapping cap-model')
             uv_unwrap(obj, profile_data['unit-length'] * profile_data['scale'] * layout_dims, pargs.partition_uv_by_face_direction)
 
-    return { 'keycap-model-name': importedModelName, 'material-names': list(colourMaterials.keys()), '~caps-with-margin-offsets': caps }
+    return { 'keycap-model-name': importedModelName, 'material-names': colourMaterials, '~caps-with-margin-offsets': caps, '~texture-image-node': imgNode, 'uv-image-path': uv_image_path, 'uv-material-name': uv_material_name }
+
+def generate_capmodel_name(intended_name:str) -> str:
+    name:str = intended_name
+    i:int = 1
+    while name in data.objects:
+        i += 1
+        name = intended_name + '-' + str(i)
+    return name
+
+def generate_shrink_wrap_materials(use_existing_materials:bool, colour_map:[dict], caps:[dict]) -> [str]:
+    colourMaterialsList:list = []
+    colourMaterialsDict:dict = {}
+    if colour_map is not None:
+        colourMaterialsDict = { m['name'] : m for m in colour_map if 'cap-colour' in m }
+        for m in colourMaterialsDict.values():
+            colourStr:str = str(m['cap-colour'])
+            colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
+            if m['name'] not in data.materials.keys() or not use_existing_materials:
+                m['material'] = data.materials.new(name=m['name'])
+                m['material'].diffuse_color = colour
+                colourMaterialsList.append(m['material'].name)
+            else:
+                m['material'] = data.materials[m['name']]
+                colourMaterialsList.append(m['name'])
+
+    # Apply materials
+    printi('Applying material colourings...')
+    for cap in caps:
+        if cap['cap-colour'] is not None:
+            if cap['cap-colour'] not in colourMaterialsDict:
+                colourStr:str = cap['cap-colour']
+                colour:[float,float,float] = tuple([ float(int(colourStr[i:i+2], 16)) / 255.0 for i in range(0, len(colourStr), 2) ] + [1.0])
+                colourMaterialsDict[colourStr] = { 'material': data.materials.new(name=cap['cap-colour']) }
+                colourMaterialsDict[colourStr]['material'].diffuse_color = colour
+            cap['cap-obj'].data.materials.append(colourMaterialsDict[cap['cap-colour']]['material'])
+            cap['cap-obj'].active_material = colourMaterialsDict[cap['cap-colour']]['material']
+
+    return colourMaterialsList
+
+
+def generate_uv_map_materials(use_existing_materials:str, uv_image_path:str, model_name:str, caps:[dict]) -> [str]:
+    uv_material_name:str = model_name + '_material'
+    if uv_material_name not in data.materials or not use_existing_materials:
+        mat = data.materials.new(name=uv_material_name)
+        mat.use_nodes = True
+        mat_nodes = mat.node_tree.nodes
+        mat_edges = mat.node_tree.links
+
+        # Get BSDF shader node
+        bsdfNode:ShaderNodeBsdfPrincipled = mat_nodes['Principled BSDF']
+
+        # Add coordinate and image nodes
+        coordsNode:ShaderNodeTexCoord = mat_nodes.new('ShaderNodeTexCoord')
+        imgNode:ShaderNodeTexImage = mat_nodes.new('ShaderNodeTexImage')
+
+        # Position the new nodes relative to the old ones
+        node_horizontal_margin_offset:Vector = Vector((300.0, 0.0))
+        imgNode.location = bsdfNode.location - node_horizontal_margin_offset
+        coordsNode.location = imgNode.location - node_horizontal_margin_offset
+
+        # Add appropriate edges
+        mat_edges.new(coordsNode.outputs['UV'], imgNode.inputs['Vector'])
+        mat_edges.new(imgNode.outputs['Color'], bsdfNode.inputs['Base Color'])
+
+    for cap in caps:
+        cap['cap-obj'].active_material = data.materials[uv_material_name]
+
+    return (imgNode, [ uv_material_name ])
 
 
 def get_data(layout: [dict], cap_dir: str, colour_map:[dict], collection:Collection, profile_data:dict) -> [dict]:

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -68,7 +68,7 @@ def adjust_glyphs(layout:[dict], profile_data:dict, layout_dims:Vector, collecti
     if pargs.glyph_application_method == 'shrinkwrap':
         svgObjectNames = import_and_align_glyphs_as_curves(scale, profile_data, collection, svg)
     else:
-        import_and_align_glyphs_as_raster(svg, imgNode, uv_image_path, uv_material_name)
+        import_and_align_glyphs_as_raster(svg, imgNode, uv_image_path, uv_material_name, Vector((pargs.uv_res, pargs.uv_res)))
 
     printi('Successfully imported glyphs')
 
@@ -108,11 +108,18 @@ def import_and_align_glyphs_as_curves(scale:float, profile_data:dict, collection
 
     return svgObjectNames
 
-def import_and_align_glyphs_as_raster(svg:str, imgNode:ShaderNodeTexImage, uv_image_path:str, uv_material_name:str):
+def import_and_align_glyphs_as_raster(svg:str, imgNode:ShaderNodeTexImage, uv_image_path:str, uv_material_name:str, uv_dims:Vector):
     # Convert to png
     png:bytes
     with Colour('transparent') as transparent:
-        with Image(blob=svg.encode('utf-8'), format='svg', background=transparent) as image:
+        image_params:dict = {
+            'blob': svg.encode('utf-8'),
+            'format': 'svg',
+            'background': transparent,
+            'width': int(uv_dims.x),
+            'height': int(uv_dims.y),
+        }
+        with Image(**image_params) as image:
             png = image.make_blob(format='png')
 
     # Write png to file

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -37,7 +37,7 @@ adjusted_svg_file_name:str = get_temp_file_name()
 # @param args:[str] Command line arguments
 #
 # @return Zero if and only if the program is to exit successfully
-def adjust_glyphs(layout:[dict], profile_data:dict, collection:Collection, glyph_map:dict, pargs:Namespace) -> [str]:
+def adjust_glyphs(layout:[dict], profile_data:dict, layout_dims:Vector, collection:Collection, glyph_map:dict, pargs:Namespace) -> [str]:
     glyph_data: [dict] = collect_data(layout, profile_data, pargs.glyph_dir, glyph_map, pargs.iso_enter_glyph_pos, pargs.alignment)
     scale:float = get_scale(profile_data['unit-length'], pargs.glyph_unit_length, pargs.svg_units_per_mm)
 
@@ -53,15 +53,12 @@ def adjust_glyphs(layout:[dict], profile_data:dict, collection:Collection, glyph
         style:str = get_style(placed_glyphs[i])
         if style:
             remove_fill_from_svg(placed_glyphs[i]['svg'])
-        placed_glyphs[i]['vector'] = get_glyph_vector_data(placed_glyphs[i], style)
+        placed_glyphs[i]['vector'] = get_glyph_vector_data(placed_glyphs[i], style, pargs.glyph_unit_length)
 
-    svgWidth: int = max(map(lambda p: p['glyph-pos'].x, placed_glyphs),
-                        default=0) + 10.0 * pargs.glyph_unit_length
-    svgHeight: int = max(map(lambda p: p['glyph-pos'].y, placed_glyphs),
-                         default=0) + 10.0 * pargs.glyph_unit_length
+    svgSideLength: int = max(layout_dims) * pargs.glyph_unit_length
     svg: str = '\n'.join([
         '<svg width="%d" height="%d" viewbox="0 0 %d %d" fill="none" xmlns="http://www.w3.org/2000/svg">'
-        % (svgWidth, svgHeight, svgWidth, svgHeight)
+        % (svgSideLength, svgSideLength, svgSideLength, svgSideLength)
     ] + list(
         map(lambda p: '\n'.join(p['vector'])
             if 'vector' in p else '', placed_glyphs)) + ['</svg>'])

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -73,7 +73,7 @@ def adjust_glyphs(layout:[dict], profile_data:dict, layout_dims:Vector, collecti
     if pargs.glyph_application_method == 'shrinkwrap':
         svgObjectNames = import_and_align_glyphs_as_curves(scale, profile_data, collection, svg)
     else:
-        import_and_align_glyphs_as_raster(svg, imgNode, uv_image_path, uv_material_name, Vector((pargs.uv_res, pargs.uv_res)))
+        import_and_align_glyphs_as_raster(svg, imgNode, uv_image_path, uv_material_name, layout_dims, pargs.uv_res, pargs.partition_uv_by_face_direction)
 
     printi('Successfully imported glyphs')
 
@@ -113,10 +113,12 @@ def import_and_align_glyphs_as_curves(scale:float, profile_data:dict, collection
 
     return svgObjectNames
 
-def import_and_align_glyphs_as_raster(svg:str, imgNode:ShaderNodeTexImage, uv_image_path:str, uv_material_name:str, uv_dims:Vector):
+def import_and_align_glyphs_as_raster(svg:str, imgNode:ShaderNodeTexImage, uv_image_path:str, uv_material_name:str, layout_dims:Vector, uv_res:float, partition_uv_by_face_direction:bool):
     # Convert to png
     png:bytes
     with Colour('transparent') as transparent:
+        m:float = min((Matrix.Diagonal((1, 2)) @ layout_dims) if partition_uv_by_face_direction else layout_dims)
+        uv_dims:Vector = (uv_res / m) * layout_dims
         image_params:dict = {
             'blob': svg.encode('utf-8'),
             'format': 'svg',

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -9,7 +9,7 @@ from .colour_resolver import colourise_layout
 from .exceptions import AdjustKeysException, AdjustKeysGracefulExit
 from .glyphinf import glyph_name
 from .input_types import type_check_colour_map, type_check_glyph_map, type_check_profile_data
-from .layout import get_layout, dumb_parse_layout
+from .layout import get_layout, dumb_parse_layout, compute_layout_dims
 from .lazy_import import LazyImport
 from .log import die, init_logging, printi, printw, print_warnings
 from .scale import get_scale
@@ -17,6 +17,7 @@ from .shrink_wrap import shrink_wrap_glyphs_to_keys
 from .update_checker import check_update
 from .util import dict_union
 from .yaml_io import read_yaml
+from mathutils import Vector
 from os import makedirs
 from os.path import exists, join
 from sys import argv, exit
@@ -87,6 +88,7 @@ def adjustkeys(*args: [[str]]) -> dict:
     layout:[dict] = []
     if pargs.adjust_glyphs or pargs.adjust_caps:
         layout:[dict] = get_layout(pargs.layout_file, profile_data, pargs.apply_colour_map)
+    layout_dims:Vector = compute_layout_dims(layout)
 
     # Read colour-map file
     colour_map:[dict] = []
@@ -108,7 +110,7 @@ def adjustkeys(*args: [[str]]) -> dict:
     # Adjust model positions
     model_data:dict = {}
     if pargs.adjust_caps:
-        model_data = adjust_caps(coloured_layout, colour_map, profile_data, collection, pargs)
+        model_data = adjust_caps(coloured_layout, colour_map, profile_data, collection, layout_dims, pargs)
 
     # Adjust glyph positions
     glyph_data:dict = {}

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -116,10 +116,13 @@ def adjustkeys(*args: [[str]]) -> dict:
     glyph_data:dict = {}
     if pargs.adjust_glyphs:
         glyph_layout:[dict] = model_data['~caps-with-margin-offsets'] if '~caps-with-margin-offsets' in model_data else coloured_layout
-        glyph_data = adjust_glyphs(glyph_layout, profile_data, layout_dims, collection, glyph_map, pargs)
+        imgNode:ShaderNodeTexImage = model_data['~texture-image-node'] if '~texture-image-node' in model_data else None
+        uv_image_path:str = model_data['uv-image-path'] if 'uv-image-path' in model_data else None
+        uv_material_name:str = model_data['uv-material-name'] if 'uv-material-name' in model_data else None
+        glyph_data = adjust_glyphs(glyph_layout, profile_data, layout_dims, collection, glyph_map, imgNode, uv_image_path, uv_material_name, pargs)
 
     # Shrink-wrap the glyphs onto the model
-    if pargs.shrink_wrap and pargs.adjust_caps and pargs.adjust_glyphs:
+    if pargs.glyph_application_method == 'shrinkwrap' and pargs.adjust_caps and pargs.adjust_glyphs:
         subsurf_params:dict = {
                 'viewport-levels': pargs.subsurf_viewport_levels,
                 'render-levels': pargs.subsurf_render_levels,

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -115,7 +115,8 @@ def adjustkeys(*args: [[str]]) -> dict:
     # Adjust glyph positions
     glyph_data:dict = {}
     if pargs.adjust_glyphs:
-        glyph_data = adjust_glyphs(model_data['~caps-with-margin-offsets'] if '~caps-with-margin-offsets' in model_data else coloured_layout, profile_data, collection, glyph_map, pargs)
+        glyph_layout:[dict] = model_data['~caps-with-margin-offsets'] if '~caps-with-margin-offsets' in model_data else coloured_layout
+        glyph_data = adjust_glyphs(glyph_layout, profile_data, layout_dims, collection, glyph_map, pargs)
 
     # Shrink-wrap the glyphs onto the model
     if pargs.shrink_wrap and pargs.adjust_caps and pargs.adjust_glyphs:

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -82,7 +82,7 @@ args: [dict] = [{
     'str-type': 'dir'
 }, {
     'dest': 'glyph_map_file',
-    'short': '-M',
+    'short': '-m',
     'long': '--glyph-map',
     'action': 'store',
     'help':
@@ -188,7 +188,7 @@ args: [dict] = [{
     'action': 'store_false',
     'help': 'Import keycap models and correctly adjust their positions',
     'default': True,
-    'label': 'Import keycap meshes',
+    'label': 'Import keycaps',
     'type': bool
 }, {
     'dest': 'adjust_glyphs',
@@ -197,7 +197,7 @@ args: [dict] = [{
     'action': 'store_false',
     'help': 'Import glyphs and correctly adjust their positions',
     'default': True,
-    'label': 'Import glyph curves',
+    'label': 'Import glyphs',
     'type': bool
 }, {
     'dest': 'apply_colour_map',
@@ -221,6 +221,15 @@ args: [dict] = [{
     'str-type': 'file',
     'label': 'YAML option file'
 }, {
+    'dest': 'partition_uv_by_face_direction',
+    'short': '-p',
+    'long': '--partition-uv-by-face-direction',
+    'action': 'store_true',
+    'help': 'Use separate areas of the uv-space for faces with upward and downward normals. Prevents prevents glyphs from appearing on the back of caps but effectively halves uv-resolution along one axis.',
+    'default': False,
+    'type': bool,
+    'label': 'Partition UV-map by face normals',
+}, {
     'dest': 'print_opts_yml',
     'short': '-#',
     'long': '--print-opts-yml',
@@ -230,6 +239,19 @@ args: [dict] = [{
     'type': bool,
     'label': 'List current options in YAML',
     'op': True
+}, {
+    'dest': 'glyph_application_method',
+    'short': '-M',
+    'long': '--glyph-application-method',
+    'action': 'store',
+    'help': 'Select the method of attaching the glyphs to the keys',
+    'default': 'uv-map',
+    'choices': [
+        'shrinkwrap',
+        'uv-map'
+    ],
+    'type': str,
+    'label': 'Glyph application method'
 }, {
     'dest': 'shrink_wrap_offset',
     'short': '-d',
@@ -291,6 +313,27 @@ args: [dict] = [{
     'type': float,
     'soft-min': 0.0,
     'soft-max': 100.0,
+}, {
+    'dest': 'use_existing_materials',
+    'short': '-e',
+    'long': '--use-existing-materials',
+    'action': 'store_true',
+    'help': "Don't create new materials for any existing ones found",
+    'default': False,
+    'type': bool,
+    'label': 'Use existing materials',
+}, {
+    'dest': 'uv_res',
+    'short': '-u',
+    'long': '--uv-res',
+    'metavar': 'res',
+    'action': 'store',
+    'help': 'Specify the length of the longest side of a uv image texture',
+    'default': 4096,
+    'label': 'UV map resolution',
+    'type': int,
+    'min': 1024,
+    'max': 8192,
 }, {
     'dest': 'verbosity',
     'short': '-v',

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -209,15 +209,6 @@ args: [dict] = [{
     'label': 'Apply colour map',
     'type': bool
 }, {
-    'dest': 'shrink_wrap',
-    'short': '-Ns',
-    'long': '--no-shrink-wrap',
-    'action': 'store_false',
-    'help': "Subdivide and shrink wrap glyph models onto the keycaps",
-    'default': True,
-    'label': 'Shrink wrap glyphs to keys',
-    'type': bool
-}, {
     'dest': 'opt_file',
     'short': '-@',
     'long': '--args',

--- a/adjustkeys/arg_defs.py
+++ b/adjustkeys/arg_defs.py
@@ -328,7 +328,7 @@ args: [dict] = [{
     'long': '--uv-res',
     'metavar': 'res',
     'action': 'store',
-    'help': 'Specify the length of the longest side of a uv image texture',
+    'help': 'Specify the length of the shortest side of a uv image texture. Large res values require a lot of memory.',
     'default': 4096,
     'label': 'UV map resolution',
     'type': int,

--- a/adjustkeys/layout.py
+++ b/adjustkeys/layout.py
@@ -224,4 +224,28 @@ def gen_cap_name(key:dict) -> str:
             name += '-bar'
         return name
 
+def compute_layout_dims(layout:[dict]) -> Vector:
+    def point_enumerator(v:Vector) -> Matrix:
+        return Matrix([
+            (0.0, 0.0,  v[0], v[0]),
+            (0.0, v[1], 0.0,  v[1])
+        ])
 
+    # Initial extreme values
+    xmax = 0.0
+    ymax = 0.0
+
+    for cap in layout:
+        rot:Matrix = Matrix.Rotation(cap['rotation'], 2)
+        primary_dims:Vector = Vector((cap['width'], cap['height']))
+        secondary_dims:Vector = Vector((cap['secondary-width'], cap['secondary-height']))
+        kle_pos_mat:Matrix = Matrix([[cap['kle-pos'][0]] * 4, [cap['kle-pos'][1]] * 4])
+
+        # This method doesn't take into account extremely weird keycap shapes (which use x2, y2 keys but it should work for everything which actually exists)
+        primary_points:Matrix = kle_pos_mat + rot @ point_enumerator(primary_dims)
+        secondary_points:Matrix = kle_pos_mat + rot @ point_enumerator(secondary_dims)
+
+        xmax = max(xmax, *primary_points[0], *secondary_points[0])
+        ymax = max(ymax, *primary_points[1], *secondary_points[1])
+
+    return Vector((xmax, ymax))

--- a/adjustkeys/util.py
+++ b/adjustkeys/util.py
@@ -266,6 +266,3 @@ def frange(x, y, jump):
     while x <= y:
         yield float(x)
         x += jump
-
-def layout_is_wider_than_height(v:'Vector') -> bool:
-    return v[0] <= 0.5 * v[1]

--- a/adjustkeys/util.py
+++ b/adjustkeys/util.py
@@ -241,3 +241,6 @@ def frange(x, y, jump):
     while x <= y:
         yield float(x)
         x += jump
+
+def layout_is_wider_than_height(v:'Vector') -> bool:
+    return v[0] <= 0.5 * v[1]

--- a/adjustkeys/util.py
+++ b/adjustkeys/util.py
@@ -178,13 +178,13 @@ def list_diff(a: list, b: list) -> list:
 # @param object
 #
 # @return
-def safe_get(a: [object], i: object) -> object:
+def safe_get(a: [object], i: object, default:object=None) -> object:
     if a is None:
-        return None
+        return default
     elif type(a) == list:
-        return a[i] if len(a) > i else None
+        return a[i] if len(a) > i else default
     elif type(a) == dict:
-        return a[i] if i in a else None
+        return a[i] if i in a else default
     else:
         die('Can\'t safely-get from unhandled type %s (more code is needed in %s)'
             % (type(a), __file__))

--- a/adjustkeys/util.py
+++ b/adjustkeys/util.py
@@ -56,22 +56,47 @@ def inner_join(las: [dict],
                cond=None) -> [dict]:
     if las == [] or lbs == []:
         return []
-    else:
 
-        def eq(a: object, b: object) -> bool:
-            return a == b
+    if cond is None:
+        cond = eq
 
-        if cond is None:
-            cond = eq
-        return list(
-            reduce(
-                concat,
-                list(
-                    map(
-                        lambda la: [
-                            dict_union(la, lb) for lb in lbs
-                            if cond(la[ka], lb[kb])
-                        ], las))))
+    return list(
+        reduce(
+            concat,
+            list(
+                map(
+                    lambda la: [
+                        dict_union(la, lb) for lb in lbs
+                        if cond(safe_get(la, ka), safe_get(lb, kb))
+                    ], las))))
+
+
+def left_outer_join(las:[dict], ka:object, lbs:[dict], kb:object, cond=None) -> [dict]:
+    if las == []:
+        return []
+    elif lbs == []:
+        return las
+
+    if cond is None:
+        cond = eq
+
+    return inner_join(las, ka, lbs, kb, cond=cond) + list(filter(lambda la: not any(map(lambda lb: cond(la[ka], lb[kb]), lbs)), las))
+
+
+def right_outer_join(las:[dict], ka:object, lbs:[dict], kb:object, cond=None) -> [dict]:
+    if lbs == []:
+        return []
+    elif las == []:
+        return lbs
+
+    if cond is None:
+        cond = eq
+
+    return inner_join(las, ka, lbs, kb, cond=cond) + list(filter(lambda lb: not any(map(lambda la: cond(la[ka], lb[kb]), las)), lbs))
+
+
+def eq(a: object, b: object) -> bool:
+    return a == b
 
 
 ##

--- a/adjustkeys/uv_unwrap.py
+++ b/adjustkeys/uv_unwrap.py
@@ -1,0 +1,39 @@
+# Copyright (C) Edward Jones
+
+from .log import printi
+from .util import layout_is_wider_than_height
+from bpy.types import MeshPolygon, Object
+from mathutils import Matrix, Vector
+
+def uv_unwrap(obj:Object, objw:Vector, partition_uv_by_face_direction:bool):
+    #  # Ensure object mode
+    #  origMode:str = context.object.mode
+    #  if origMode != 'OBJECT':
+        #  ops.object.mode_set(mode='OBJECT')
+
+    # Project vertices into uv-space, assuming upper-left most point is at
+    scale: float = uv_scale(objw)
+    diag:[float] = diagonal(scale)
+    wide_layout:bool = layout_is_wider_than_height(objw)
+    printi('Scaling uv image by (%f, %f)' %(diag[0], diag[1]))
+    for face in obj.data.polygons:
+        for vert_idx, loop_idx in zip(face.vertices, face.loop_indices):
+            place_off:float = 1.0 if not partition_uv_by_face_direction or is_front_face(obj, face) else 0.5
+            off:Vector = Vector((0.0, place_off)) if layout_is_wider_than_height else Vector((place_off, 0.0))
+            obj.data.uv_layers.active.data[loop_idx].uv = scale @ obj.data.vertices[vert_idx].co.to_2d() + off
+
+    #  # Reinstate previous mode
+    #  if origMode != 'OBJECT':
+        #  ops.object.mode_set(mode=origMode)
+
+
+# Assume that the top left-most point occupied space is at (0,0)
+def uv_scale(kbw:Vector) -> Matrix:
+    return Matrix.Scale(1.0 / kbw[layout_is_wider_than_height(kbw)], 2)
+
+def is_front_face(o:Object, f:MeshPolygon) -> bool:
+    return max(map(lambda vi: o.data.vertices[vi].normal @ Vector((0.0, 1.0, 0.0)), f.vertices)) >= 0.0
+
+# Assumes square matrix
+def diagonal(m:Matrix) -> [float]:
+    return [ m[i][i] for i in range(0, len(m[0])) ]

--- a/adjustkeys/uv_unwrap.py
+++ b/adjustkeys/uv_unwrap.py
@@ -1,7 +1,6 @@
 # Copyright (C) Edward Jones
 
 from .log import printi
-from .util import layout_is_wider_than_height
 from bpy.types import MeshPolygon, Object
 from mathutils import Matrix, Vector
 
@@ -12,14 +11,14 @@ def uv_unwrap(obj:Object, objw:Vector, partition_uv_by_face_direction:bool):
         #  ops.object.mode_set(mode='OBJECT')
 
     # Project vertices into uv-space, assuming upper-left most point is at
-    scale: float = uv_scale(objw)
+    scale: float = uv_scale(partition_uv_by_face_direction, objw)
     diag:[float] = diagonal(scale)
-    wide_layout:bool = layout_is_wider_than_height(objw)
     printi('Scaling uv image by (%f, %f)' %(diag[0], diag[1]))
     for face in obj.data.polygons:
+        front_face:bool = is_front_face(obj, face)
         for vert_idx, loop_idx in zip(face.vertices, face.loop_indices):
-            place_off:float = 1.0 if not partition_uv_by_face_direction or is_front_face(obj, face) else 0.5
-            off:Vector = Vector((0.0, place_off)) if layout_is_wider_than_height else Vector((place_off, 0.0))
+            place_off:float = 1.0 if not partition_uv_by_face_direction or front_face else 0.5
+            off:Vector = Vector((0.0, place_off))
             obj.data.uv_layers.active.data[loop_idx].uv = scale @ obj.data.vertices[vert_idx].co.to_2d() + off
 
     #  # Reinstate previous mode
@@ -28,8 +27,15 @@ def uv_unwrap(obj:Object, objw:Vector, partition_uv_by_face_direction:bool):
 
 
 # Assume that the top left-most point occupied space is at (0,0)
-def uv_scale(kbw:Vector) -> Matrix:
-    return Matrix.Scale(1.0 / kbw[layout_is_wider_than_height(kbw)], 2)
+def uv_scale(partition_uv_by_face_direction:bool, kbw:Vector) -> Matrix:
+    # Matrix to scale to the space [0,1]^2
+    uv_scale_mat:Matrix = Matrix.Diagonal(kbw).inverted()
+
+    # Halve the second componenet if partitioning
+    if partition_uv_by_face_direction:
+        uv_scale_mat @= Matrix.Diagonal((1, 0.5))
+
+    return uv_scale_mat
 
 def is_front_face(o:Object, f:MeshPolygon) -> bool:
     return max(map(lambda vi: o.data.vertices[vi].normal @ Vector((0.0, 1.0, 0.0)), f.vertices)) >= 0.0


### PR DESCRIPTION
### What's changed?

Previously, shrink-wrapping was the only option for applying glyphs to caps, however this method adds many points and vertices which can sow down renders.
Now, a new default option for uv-wrapping has been added which:

- Uses a significant proportion of uv-space (no less than with conventional uv-unwrapping from a viewpoint)
- Has customisable resolution
- Allows upward-normal and downward-normal keycap model faces to be partitioned, allowing keycaps to be viewed from all angles if desired

### Check lists

- [x] Compiled with Cython
