### PR TITLE
More expressive colour map conditions

### DIFF
--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -320,7 +320,7 @@ def get_style(key:dict, style_key:str) -> str:
             style = 'style="%s"' % raw_style.replace('\\', '\\\\').replace('"', '\\"')
         return style
     else:
-        printw('Style key "%s" not present in whichever rule was intended for key "%s"' % (style_key, key['key']))
+        printw('Style key "%s" was never applied to key "%s"' % (style_key, key['key']))
         return ''
 
 def get_glyph_vector_data(glyph:dict, style:str, ulen:float, glyph_application_method:float, partition_uv_by_face_direction:bool, layout_dims:Vector) -> [str]:

--- a/adjustkeys/adjustkeys.py
+++ b/adjustkeys/adjustkeys.py
@@ -5,10 +5,11 @@ from .adjustcaps import adjust_caps, get_caps
 from .adjustglyphs import adjust_glyphs, glyph_files
 from .args import parse_args, Namespace
 from .blender_available import blender_available
+from .colour_map_parser import parse_colour_map
 from .colour_resolver import colourise_layout
 from .exceptions import AdjustKeysException, AdjustKeysGracefulExit
 from .glyphinf import glyph_name
-from .input_types import type_check_colour_map, type_check_glyph_map, type_check_profile_data
+from .input_types import type_check_glyph_map, type_check_profile_data
 from .layout import get_layout, dumb_parse_layout, compute_layout_dims
 from .lazy_import import LazyImport
 from .log import die, init_logging, printi, printw, print_warnings
@@ -92,11 +93,9 @@ def adjustkeys(*args: [[str]]) -> dict:
     # Read colour-map file
     colour_map:[dict] = None
     if pargs.apply_colour_map:
-        colour_map:[dict] = read_yaml(pargs.colour_map_file)
-        if pargs.apply_colour_map and not type_check_colour_map(colour_map):
-            die('Colour map failed type-checking, see console for more information')
+        colour_map:[dict] = parse_colour_map(pargs.colour_map_file)
 
-    coloured_layout:[dict] = colourise_layout(layout, colour_map)
+    coloured_layout:[dict] = colourise_layout(pargs.layout_file, layout, colour_map)
 
     glyph_map:dict = {}
     if pargs.adjust_glyphs:

--- a/adjustkeys/colour_map_parser.py
+++ b/adjustkeys/colour_map_parser.py
@@ -128,6 +128,7 @@ def recursively_add(old_key:str, new_key:str, f:Callable, data:object) -> object
         int: lambda i: i,
         list: lambda l: list(map(lambda e: recursively_add(old_key, new_key, f, e), data)),
         str: lambda s: s,
+        bool: lambda b: b,
         type(None): lambda n: n,
         type(lambda:None): lambda f: f,
     }

--- a/adjustkeys/colour_map_parser.py
+++ b/adjustkeys/colour_map_parser.py
@@ -56,9 +56,7 @@ def parse_colour_map(fname:str) -> [dict]:
     ]
     colour_map:[dict] = raw_map
     for mappingInf in mappings:
-        #  colour_map = map(partial(recursively_add, *mappingInf), colour_map)
         colour_map = recursively_add(*mappingInf, colour_map)
-        print(list(colour_map))
 
     return list(colour_map)
 
@@ -66,9 +64,6 @@ def sanitise_key_name(rule:dict) -> dict:
     if 'key-name' in rule and type(rule['key-name']) == str:
         rule['key-name'] = [rule['key-name']]
     return rule
-
-#  def parse_equations(rule:dict) -> dict:
-    #  return recursively_add(rule, 'key-pos', 'parsed-key-pos', parse_equation)
 
 def parse_equation(eq:str) -> dict:
     ParserElement.enablePackrat()

--- a/adjustkeys/colour_map_parser.py
+++ b/adjustkeys/colour_map_parser.py
@@ -1,0 +1,139 @@
+from .input_types import type_check_colour_map
+from .log import die, printe
+from .util import dict_union
+from .yaml_io import read_yaml
+from collections import OrderedDict
+from functools import partial
+from pyparsing import infixNotation, Literal, oneOf, opAssoc, ParserElement, ParseException, pyparsing_common, Word
+from sys import getrecursionlimit, setrecursionlimit, stderr
+from typing import Callable, Iterator, List, Tuple
+
+LOWER_RECURSION_LIMIT:int = 3000
+
+uniops:OrderedDict = OrderedDict([
+        ('+', lambda v: v),
+        ('-', lambda v: -v),
+    ])
+binops:OrderedDict = OrderedDict([
+        ('^^', lambda a,b: a ** b),
+        ('*', lambda a,b: a * b),
+        ('/', lambda a,b: a / b),
+        ('//', lambda a,b: a // b),
+        ('%', lambda a,b: a % b),
+        ('+', lambda a,b: a + b),
+        ('-', lambda a,b: a - b),
+    ])
+compops:OrderedDict = OrderedDict([
+        ('<', lambda a,b: a < b),
+        ('<=', lambda a,b: a <= b),
+        ('>', lambda a,b: a > b),
+        ('>=', lambda a,b: a >= b),
+        ('=', lambda a,b: a == b),
+        ('==', lambda a,b: a == b),
+        ('!=', lambda a,b: a != b),
+    ])
+logicuniops:OrderedDict = OrderedDict([
+        ('!', lambda c: not c),
+    ])
+logicbinops:OrderedDict = OrderedDict([
+        ('&', lambda c1,c2: c1 and c2),
+        ('|', lambda c1,c2: c1 or c2),
+        ('^', lambda c1,c2: c1 ^ c2),
+        ('=>', lambda c1,c2: not c1 or c2),
+        ('<=>', lambda c1,c2: bool(c1) == bool(c2)),
+    ])
+ops = dict_union(uniops, binops, compops, logicuniops, logicbinops)
+
+def parse_colour_map(fname:str) -> [dict]:
+    raw_map:[dict] = read_yaml(fname)
+
+    if not type_check_colour_map(raw_map):
+        die('Colour map failed type-checking, see console for more information')
+
+    mappings:[Tuple[str, str, Callable]] = [
+        ('key-pos', 'parsed-key-pos', parse_equation),
+        ('key-name', 'key-name', sanitise_key_name),
+    ]
+    colour_map:[dict] = raw_map
+    for mappingInf in mappings:
+        #  colour_map = map(partial(recursively_add, *mappingInf), colour_map)
+        colour_map = recursively_add(*mappingInf, colour_map)
+        print(list(colour_map))
+
+    return list(colour_map)
+
+def sanitise_key_name(rule:dict) -> dict:
+    if 'key-name' in rule and type(rule['key-name']) == str:
+        rule['key-name'] = [rule['key-name']]
+    return rule
+
+#  def parse_equations(rule:dict) -> dict:
+    #  return recursively_add(rule, 'key-pos', 'parsed-key-pos', parse_equation)
+
+def parse_equation(eq:str) -> dict:
+    ParserElement.enablePackrat()
+
+    if getrecursionlimit() < LOWER_RECURSION_LIMIT:
+        setrecursionlimit(LOWER_RECURSION_LIMIT)
+
+    # Define atoms
+    NUM = pyparsing_common.number
+    VARIABLE = Word(['x', 'y', 'X', 'Y'], exact=True)
+    operand = NUM | VARIABLE
+
+    # Define production rules
+    expr = infixNotation(operand,
+            [ (Literal(op), 1, opAssoc.RIGHT, op_rep) for op in uniops ]
+            + [ (Literal(op), 2, opAssoc.LEFT, op_rep) for op in binops ]
+        )
+    comp = infixNotation(expr,
+            [ (Literal(op), 2, opAssoc.LEFT, op_rep) for op in compops ]
+        )
+    cond = infixNotation(comp,
+            [ (Literal(op), 1, opAssoc.RIGHT, op_rep) for op in logicuniops ]
+            + [ (Literal(op), 2, opAssoc.LEFT, op_rep) for op in logicbinops ]
+        )
+
+    try:
+        return cond.parseString(eq, parseAll=True)[0]
+    except ParseException as pex:
+        printe('Error while parsing "%s": %s' %(eq, str(pex)))
+        return None
+
+def op_rep(_1:str, _2:int, toks:List[object]) -> dict:
+    toks = toks[0]
+    op:str
+    op_args:[object]
+    if len(toks) == 2:
+        op = toks[0]
+        op_args = [toks[1]]
+    elif len(toks) == 3:
+        op = toks[1]
+        op_args = [toks[0], toks[2]]
+    else:
+        printe('Unknown number of tokens: %d in %s' %(len(toks), list(map(str, toks))))
+        exit(1)
+    return {
+        'op': ops[op],
+        'pretty-op': op,
+        'args': op_args,
+    }
+
+def recursively_add(old_key:str, new_key:str, f:Callable, data:object) -> object:
+    rules:dict = {
+        dict: lambda d: dict_union(
+            {
+                k: (recursively_add(old_key, new_key, f, v) if k != old_key else v)
+                    for k,v in d.items()
+            },
+            { new_key: f(d[old_key]) }
+                if old_key in d else {}
+        ),
+        float: lambda f: f,
+        int: lambda i: i,
+        list: lambda l: list(map(lambda e: recursively_add(old_key, new_key, f, e), data)),
+        str: lambda s: s,
+        type(None): lambda n: n,
+        type(lambda:None): lambda f: f,
+    }
+    return rules[type(data)](data)

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -66,20 +66,20 @@ def resolve_matches(layout_context:dict, cap:dict, rule:Union[bool, dict]) -> [b
             printi('%r' % cond_result)
 
             conds.append(cond_result)
-        if statementKey.startswith('key-pos'):
+        elif statementKey.startswith('key-pos'):
             printi_name('Checking key position (%.4fu,%.4fu) satisfies condition "%s"...' % (cap['kle-pos'].x, cap['kle-pos'].y, rule['key-pos']), end=' ')
             print(rule)
             cond_result:bool = eval_maths_cond(cap, rule['parsed-key-pos'])
             printi('%r' % cond_result)
 
             conds.append(cond_result)
-        if statementKey.startswith('layout-file-name'):
+        elif statementKey.startswith('layout-file-name'):
             printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-name'], rule['layout-file-name']), end=' ')
             cond_result:bool = match('^%s$' % rule['layout-file-name'], layout_context['layout-file-name'], IGNORECASE | UNICODE) is not None
             printi('%r' % cond_result)
 
             conds.append(cond_result)
-        if statementKey.startswith('layout-file-path'):
+        elif statementKey.startswith('layout-file-path'):
             printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-path'], rule['layout-file-path']), end=' ')
             cond_result:bool = match('^%s$' % rule['layout-file-path'], layout_context['layout-file-path'], IGNORECASE | UNICODE) is not None
             printi('%r' % cond_result)
@@ -89,11 +89,11 @@ def resolve_matches(layout_context:dict, cap:dict, rule:Union[bool, dict]) -> [b
         # Resolve sub-conditions
         if statementKey.startswith('any'):
             conds.append(any(resolve_matches(layout_context, cap, rule[statementKey])))
-        if statementKey.startswith('all'):
+        elif statementKey.startswith('all'):
             conds.append(all(resolve_matches(layout_context, cap, rule[statementKey])))
-        if statementKey.startswith('not-all'):
+        elif statementKey.startswith('not-all'):
             conds.append(not all(resolve_matches(layout_context, cap, rule[statementKey])))
-        if statementKey.startswith('not-any'):
+        elif statementKey.startswith('not-any'):
             conds.append(not any(resolve_matches(layout_context, cap, rule[statementKey])))
 
     return conds

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -5,7 +5,7 @@ from functools import partial
 from mathutils import Matrix, Vector
 from os import sep
 from os.path import basename, split, splitext
-from re import IGNORECASE, match, U
+from re import IGNORECASE, match, UNICODE
 from typing import Callable, List, Tuple, Union
 
 def colourise_layout(layout_file_path:str, layout:[dict], colour_map:[dict]) -> [dict]:
@@ -54,43 +54,44 @@ def resolve_matches(layout_context:dict, cap:dict, rule:dict) -> [bool]:
     conds:[bool] = []
 
     # Resolve conditions at this level
-    if 'key-name' in rule:
-        printi_name('Checking key name "%s" entirely matches any of' % cap['key'], end=' ')
-        key_name_regexes = rule['key-name'] if type(rule['key-name']) == list else [rule['key-name']]
-        printi('[ %s ]...' % ', '.join(list(map(lambda r: '"%s"' % r, key_name_regexes))), end=' ')
-        cond_result:bool = any(map(lambda r: match('^%s$' % r, cap['key'], IGNORECASE | U) is not None, key_name_regexes))
-        printi('%r' % cond_result)
+    for statementKey in rule:
+        if statementKey.startswith('key-name'):
+            printi_name('Checking key name "%s" entirely matches any of' % cap['key'], end=' ')
+            key_name_regexes = rule['key-name'] if type(rule['key-name']) == list else [rule['key-name']]
+            printi('[ %s ]...' % ', '.join(list(map(lambda r: '"%s"' % r, key_name_regexes))), end=' ')
+            cond_result:bool = any(map(lambda r: match('^%s$' % r, cap['key'], IGNORECASE | UNICODE) is not None, key_name_regexes))
+            printi('%r' % cond_result)
 
-        conds.append(cond_result)
-    if 'key-pos' in rule:
-        printi_name('Checking key position (%.4fu,%.4fu) satisfies condition "%s"...' % (cap['kle-pos'].x, cap['kle-pos'].y, rule['key-pos']), end=' ')
-        print(rule)
-        cond_result:bool = eval_maths_cond(cap, rule['parsed-key-pos'])
-        printi('%r' % cond_result)
+            conds.append(cond_result)
+        if statementKey.startswith('key-pos'):
+            printi_name('Checking key position (%.4fu,%.4fu) satisfies condition "%s"...' % (cap['kle-pos'].x, cap['kle-pos'].y, rule['key-pos']), end=' ')
+            print(rule)
+            cond_result:bool = eval_maths_cond(cap, rule['parsed-key-pos'])
+            printi('%r' % cond_result)
 
-        conds.append(cond_result)
-    if 'layout-file-name' in rule:
-        printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-name'], rule['layout-file-name']), end=' ')
-        cond_result:bool = match('^%s$' % rule['layout-file-name'], layout_context['layout-file-name'], IGNORECASE | U) is not None
-        printi('%r' % cond_result)
+            conds.append(cond_result)
+        if statementKey.startswith('layout-file-name'):
+            printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-name'], rule['layout-file-name']), end=' ')
+            cond_result:bool = match('^%s$' % rule['layout-file-name'], layout_context['layout-file-name'], IGNORECASE | UNICODE) is not None
+            printi('%r' % cond_result)
 
-        conds.append(cond_result)
-    if 'layout-file-path' in rule:
-        printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-path'], rule['layout-file-path']), end=' ')
-        cond_result:bool = match('^%s$' % rule['layout-file-path'], layout_context['layout-file-path'], IGNORECASE | U) is not None
-        printi('%r' % cond_result)
+            conds.append(cond_result)
+        if statementKey.startswith('layout-file-path'):
+            printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-path'], rule['layout-file-path']), end=' ')
+            cond_result:bool = match('^%s$' % rule['layout-file-path'], layout_context['layout-file-path'], IGNORECASE | UNICODE) is not None
+            printi('%r' % cond_result)
 
-        conds.append(cond_result)
+            conds.append(cond_result)
 
-    # Resolve sub-conditions
-    if 'any' in rule:
-        conds.append(any(resolve_matches(layout_context, cap, rule['any'])))
-    if 'all' in rule:
-        conds.append(all(resolve_matches(layout_context, cap, rule['all'])))
-    if 'not-all' in rule:
-        conds.append(not all(resolve_matches(layout_context, cap, rule['not-all'])))
-    if 'not-any' in rule:
-        conds.append(not any(resolve_matches(layout_context, cap, rule['not-any'])))
+        # Resolve sub-conditions
+        if statementKey.startswith('any'):
+            conds.append(any(resolve_matches(layout_context, cap, rule[statementKey])))
+        if statementKey.startswith('all'):
+            conds.append(all(resolve_matches(layout_context, cap, rule[statementKey])))
+        if statementKey.startswith('not-all'):
+            conds.append(not all(resolve_matches(layout_context, cap, rule[statementKey])))
+        if statementKey.startswith('not-any'):
+            conds.append(not any(resolve_matches(layout_context, cap, rule[statementKey])))
 
     return conds
 

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -1,27 +1,112 @@
 # Copyright (C) Edward Jones
 
-from re import IGNORECASE, match
-from typing import Tuple
+from .log import printi
+from functools import partial
+from mathutils import Matrix, Vector
+from os import sep
+from os.path import basename, split, splitext
+from re import IGNORECASE, match, U
+from typing import Callable, List, Tuple, Union
 
-def colourise_layout(layout:[dict], colour_map:[dict]) -> [dict]:
+def colourise_layout(layout_file_path:str, layout:[dict], colour_map:[dict]) -> [dict]:
+    layout_context:dict = {
+            'layout-file-path': sanitise_path(layout_file_path),
+            'layout-file-name': splitext(basename(layout_file_path))[0],
+        }
     for key in layout:
-        apply_sanitised_colouring(key, colour_map, 'cap-style', 'cap-style-raw', 'cap-style')
-        apply_sanitised_colouring(key, colour_map, 'glyph-style', 'glyph-colour-raw', 'glyph-style')
+        apply_sanitised_colouring(layout_context, key, colour_map, 'cap-style', 'cap-style-raw', 'cap-style')
+        apply_sanitised_colouring(layout_context, key, colour_map, 'glyph-style', 'glyph-colour-raw', 'glyph-style')
     return layout
 
-def apply_sanitised_colouring(key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str):
-    (key[target_key], key[target_key + '-rule']) = sanitise_colour(get_colouring(key, colour_map, target_key, raw_key, extraction_key))
+def sanitise_path(path:str) -> str:
+    folders = []
+    while True:
+        path, folder = split(path)
+        if folder != "":
+            folders.append(folder)
+        else:
+            if path != "":
+                folders.append(path)
+            break
+    folders.reverse()
+    return '/'.join(folders)
 
-def get_colouring(key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str) -> Tuple[str, str]:
+def apply_sanitised_colouring(layout_context:dict, key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str):
+    (key[target_key], key[target_key + '-rule']) = sanitise_colour(get_colouring(layout_context, key, colour_map, target_key, raw_key, extraction_key))
+
+def get_colouring(layout_context:dict, key:dict, colour_map:[dict], target_key:str, raw_key:str, extraction_key:str) -> Tuple[str, str]:
     if raw_key in key and key[raw_key] is not None:
         return (key[raw_key], None)
     else:
         if colour_map is not None:
-            key_name = key['key']
             for mapping in colour_map:
-                if target_key in mapping and any(map(lambda r: match('^' + r + '$', key_name, IGNORECASE) is not None, mapping['keys'])):
+                if target_key in mapping and rule_match(layout_context, key, mapping):
                     return (mapping[extraction_key], mapping['name'])
         return (None, None)
+
+def rule_match(layout_context:dict, key:dict, rule:dict) -> bool:
+    return all(resolve_matches(layout_context, key, rule['cond']))
+    #  key_name:str = key['key']
+    #  return any(map(lambda r: match('^' + r + '$', key_name, IGNORECASE) is not None, rule['keys']))
+
+def resolve_matches(layout_context:dict, cap:dict, rule:dict) -> [bool]:
+    printi_name:Callable = partial(printi, '%s:' % layout_context['layout-file-name'])
+    conds:[bool] = []
+
+    # Resolve conditions at this level
+    if 'key-name' in rule:
+        printi_name('Checking key name "%s" entirely matches any of' % cap['key'], end=' ')
+        key_name_regexes = rule['key-name'] if type(rule['key-name']) == list else [rule['key-name']]
+        printi('[ %s ]...' % ', '.join(list(map(lambda r: '"%s"' % r, key_name_regexes))), end=' ')
+        cond_result:bool = any(map(lambda r: match('^%s$' % r, cap['key'], IGNORECASE | U) is not None, key_name_regexes))
+        printi('%r' % cond_result)
+
+        conds.append(cond_result)
+    if 'key-pos' in rule:
+        printi_name('Checking key position (%.4fu,%.4fu) satisfies condition "%s"...' % (cap['kle-pos'].x, cap['kle-pos'].y, rule['key-pos']), end=' ')
+        print(rule)
+        cond_result:bool = eval_maths_cond(cap, rule['parsed-key-pos'])
+        printi('%r' % cond_result)
+
+        conds.append(cond_result)
+    if 'layout-file-name' in rule:
+        printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-name'], rule['layout-file-name']), end=' ')
+        cond_result:bool = match('^%s$' % rule['layout-file-name'], layout_context['layout-file-name'], IGNORECASE | U) is not None
+        printi('%r' % cond_result)
+
+        conds.append(cond_result)
+    if 'layout-file-path' in rule:
+        printi_name('Checking "%s" entirely matches "%s"...' % (layout_context['layout-file-path'], rule['layout-file-path']), end=' ')
+        cond_result:bool = match('^%s$' % rule['layout-file-path'], layout_context['layout-file-path'], IGNORECASE | U) is not None
+        printi('%r' % cond_result)
+
+        conds.append(cond_result)
+
+    # Resolve sub-conditions
+    if 'any' in rule:
+        conds.append(any(resolve_matches(layout_context, cap, rule['any'])))
+    if 'all' in rule:
+        conds.append(all(resolve_matches(layout_context, cap, rule['all'])))
+    if 'not-all' in rule:
+        conds.append(not all(resolve_matches(layout_context, cap, rule['not-all'])))
+    if 'not-any' in rule:
+        conds.append(not any(resolve_matches(layout_context, cap, rule['not-any'])))
+
+    return conds
+
+def eval_maths_cond(cap:dict, pos_cond:Union[str, int, float, dict]) -> object:
+    if type(pos_cond) in [int, float]:
+        return pos_cond
+    elif type(pos_cond) == str:
+        return {
+            'x': lambda: cap['kle-pos'].x,
+            'y': lambda: cap['kle-pos'].y,
+            'X': lambda: (cap['kle-pos'] + 0.5 * Matrix.Rotation(cap['rotation'], 2) @ Vector((cap['secondary-width'], cap['secondary-height']))).x,
+            'Y': lambda: (cap['kle-pos'] + 0.5 * Matrix.Rotation(cap['rotation'], 2) @ Vector((cap['secondary-width'], cap['secondary-height']))).y,
+        }[pos_cond]()
+    elif type(pos_cond) == dict:
+        eval_cap_cond:Callable = partial(eval_maths_cond, cap)
+        return pos_cond['op'](*tuple(map(eval_cap_cond, pos_cond['args'])))
 
 def sanitise_colour(colour_str:str) -> str:
     if colour_str is None:

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -87,7 +87,11 @@ def resolve_matches(layout_context:dict, cap:dict, rule:Union[bool, dict]) -> [b
             conds.append(cond_result)
 
         # Resolve sub-conditions
-        if statementKey.startswith('any'):
+        elif statementKey.startswith('implication'):
+            lhs:bool = all(resolve_matches(layout_context, cap, rule[statementKey]['lhs']))
+            rhs:bool = all(resolve_matches(layout_context, cap, rule[statementKey]['rhs']))
+            conds.append(not lhs or rhs)
+        elif statementKey.startswith('any'):
             conds.append(any(resolve_matches(layout_context, cap, rule[statementKey])))
         elif statementKey.startswith('all'):
             conds.append(all(resolve_matches(layout_context, cap, rule[statementKey])))

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -49,7 +49,10 @@ def rule_match(layout_context:dict, key:dict, rule:dict) -> bool:
     #  key_name:str = key['key']
     #  return any(map(lambda r: match('^' + r + '$', key_name, IGNORECASE) is not None, rule['keys']))
 
-def resolve_matches(layout_context:dict, cap:dict, rule:dict) -> [bool]:
+def resolve_matches(layout_context:dict, cap:dict, rule:Union[bool, dict]) -> [bool]:
+    if type(rule) == bool:
+        return [rule]
+
     printi_name:Callable = partial(printi, '%s:' % layout_context['layout-file-name'])
     conds:[bool] = []
 

--- a/adjustkeys/colour_resolver.py
+++ b/adjustkeys/colour_resolver.py
@@ -88,9 +88,12 @@ def resolve_matches(layout_context:dict, cap:dict, rule:Union[bool, dict]) -> [b
 
         # Resolve sub-conditions
         elif statementKey.startswith('implication'):
-            lhs:bool = all(resolve_matches(layout_context, cap, rule[statementKey]['lhs']))
-            rhs:bool = all(resolve_matches(layout_context, cap, rule[statementKey]['rhs']))
-            conds.append(not lhs or rhs)
+            if all(resolve_matches(layout_context, cap, rule[statementKey]['if'])):
+                conds.append(all(resolve_matches(layout_context, cap, rule[statementKey]['then'])))
+            elif 'else' in rule[statementKey]:
+                conds.append(all(resolve_matches(layout_context, cap, rule[statementKey]['else'])))
+            else:
+                conds.append(True)
         elif statementKey.startswith('any'):
             conds.append(any(resolve_matches(layout_context, cap, rule[statementKey])))
         elif statementKey.startswith('all'):

--- a/adjustkeys/input_types.py
+++ b/adjustkeys/input_types.py
@@ -3,6 +3,7 @@
 from .log import printe
 from .util import list_diff
 from re import IGNORECASE, match
+from typing import Union
 
 # The equivalent Haskell code to do all this would add a total of zero extra lines to the existing program. Thanks Python, get a type system.
 
@@ -109,7 +110,13 @@ def type_check_colour_map(cm:object) -> [[bool, bool]]:
 
     return okay
 
-def type_check_cond(p:bool, rule:dict) -> bool:
+def type_check_cond(p:bool, rule:Union[bool, dict]) -> bool:
+    if type(rule) == bool:
+        return True
+    elif type(rule) != dict:
+        printe('Expected dictionary of boolean for rule, got %s: "%s"' % (str(type(rule)), str(rule)))
+        return False
+
     conditions:dict = {
         'key-name': lambda p,k: assert_cond(p, type(rule[k]) == str or (type(rule[k]) == list and all(map(lambda k: type(k) in [str, int], rule[k]))), 'key-name field should be either a single key or list of keys, got "%s"' %(', '.join(rule[k]) if isinstance(rule[k], list) else rule[k])),
         'key-pos': lambda p,k: assert_type(p, rule[k], str, 'key-pos field takes an expression, got %s' % rule[k]),

--- a/adjustkeys/input_types.py
+++ b/adjustkeys/input_types.py
@@ -103,6 +103,7 @@ def type_check_colour_map(cm:object) -> [[bool, bool]]:
             (okay, t) = assert_dict_key(okay, rule, 'cond', 'Colour-map rules require a condition they should apply to')
             if t:
                 okay = type_check_cond(okay, rule['cond'])
+            (okay, _) = assert_cond(okay, 'cap-style' in rule or 'glyph-style' in rule, 'Colour map rules should contain at least one of "cap-style" or "glyph-style"')
             if 'cap-style' in rule:
                 (okay, _) = assert_type(okay, rule['cap-style'], str, 'Cap-styles should be strings, got %s' % (str(rule['cap-style'])))
             if 'glyph-style' in rule:

--- a/adjustkeys/input_types.py
+++ b/adjustkeys/input_types.py
@@ -111,23 +111,24 @@ def type_check_colour_map(cm:object) -> [[bool, bool]]:
 
 def type_check_cond(p:bool, rule:dict) -> bool:
     conditions:dict = {
-        'key-name': lambda p: assert_cond(p, type(rule['key-name']) == str or (type(rule['key-name']) == list and all(map(lambda k: type(k) in [str, int], rule['key-name']))), 'key-name field should be either a single key or list of keys, got "%s"' %(', '.join(rule['key-name']) if isinstance(rule['key-name'], list) else rule['key-name'])),
-        'key-pos': lambda p: assert_type(p, rule['key-pos'], str, 'key-pos field takes an expression, got %s' % rule['key-pos']),
-        'layout-file-name': lambda p: assert_type(p, rule['layout-file-name'], str, 'Layout-file-name field should be a string, got %s' % rule['layout-file-name']),
-        'layout-file-path': lambda p: assert_type(p, rule['layout-file-path'], str, 'Layout-file-path field should be a string, got %s' % rule['layout-file-path']),
-        'all': lambda p: (type_check_cond(p, rule['all']), None),
-        'any': lambda p: (type_check_cond(p, rule['any']), None),
-        'not-all': lambda p: (type_check_cond(p, rule['not-all']), None),
-        'not-any': lambda p: (type_check_cond(p, rule['not-any']), None),
+        'key-name': lambda p,k: assert_cond(p, type(rule[k]) == str or (type(rule[k]) == list and all(map(lambda k: type(k) in [str, int], rule[k]))), 'key-name field should be either a single key or list of keys, got "%s"' %(', '.join(rule[k]) if isinstance(rule[k], list) else rule[k])),
+        'key-pos': lambda p,k: assert_type(p, rule[k], str, 'key-pos field takes an expression, got %s' % rule[k]),
+        'layout-file-name': lambda p,k: assert_type(p, rule[k], str, 'Layout-file-name field should be a string, got %s' % rule[k]),
+        'layout-file-path': lambda p,k: assert_type(p, rule[k], str, 'Layout-file-path field should be a string, got %s' % rule[k]),
+        'all': lambda p,k: (type_check_cond(p, rule[k]), None),
+        'any': lambda p,k: (type_check_cond(p, rule[k]), None),
+        'not-all': lambda p,k: (type_check_cond(p, rule[k]), None),
+        'not-any': lambda p,k: (type_check_cond(p, rule[k]), None),
     }
     (p, _) = assert_cond(p, any(map(lambda k: k in rule, conditions.keys())), 'Rule needs at least one of: %s' % ', '.join(list(conditions.keys())))
 
     for field in rule.keys():
-        if field not in conditions:
+        if not any(map(lambda c: field.startswith(c), conditions)):
             printe('Unrecognised colour map rule field %s, is this a typo?' % field)
             p = False
         else:
-            (p, _) = conditions[field](p)
+            condKey:str = list(filter(lambda c: field.startswith(c), conditions))[0]
+            (p, _) = conditions[condKey](p, field)
 
     return p
 

--- a/adjustkeys/input_types.py
+++ b/adjustkeys/input_types.py
@@ -142,21 +142,24 @@ def type_check_cond(p:bool, rule:Union[bool, dict]) -> bool:
     return p
 
 def type_check_implication(p:bool, rule:Union[dict]) -> bool:
-    (p, c) = assert_type(p, rule, dict, 'Implication rule should be a dictionary with an "lhs" and an "rhs" field, got "%s" instead' % str(rule))
+    (p, c) = assert_type(p, rule, dict, 'Implication rule should be a dictionary with an "if" and an "then" field, got "%s" instead' % str(rule))
     if not c:
         return False
 
-    if 'lhs' in rule:
-        p = type_check_cond(p, rule['lhs'])
+    if 'if' in rule:
+        p = type_check_cond(p, rule['if'])
     else:
-        printe('Implication rule requires "lhs" key')
+        printe('Implication rule requires "if" key')
         p = False
 
-    if 'rhs' in rule:
-        p = type_check_cond(p, rule['rhs'])
+    if 'then' in rule:
+        p = type_check_cond(p, rule['then'])
     else:
-        printe('Implication rule requires "rhs" key')
+        printe('Implication rule requires "then" key')
         p = False
+
+    if 'else' in rule:
+        p = type_check_cond(p, rule['else'])
 
     return p
 

--- a/adjustkeys/input_types.py
+++ b/adjustkeys/input_types.py
@@ -126,6 +126,7 @@ def type_check_cond(p:bool, rule:Union[bool, dict]) -> bool:
         'any': lambda p,k: (type_check_cond(p, rule[k]), None),
         'not-all': lambda p,k: (type_check_cond(p, rule[k]), None),
         'not-any': lambda p,k: (type_check_cond(p, rule[k]), None),
+        'implication': lambda p,k: (type_check_implication(p, rule[k]), None)
     }
     (p, _) = assert_cond(p, any(map(lambda k: k in rule, conditions.keys())), 'Rule needs at least one of: %s' % ', '.join(list(conditions.keys())))
 
@@ -136,6 +137,25 @@ def type_check_cond(p:bool, rule:Union[bool, dict]) -> bool:
         else:
             condKey:str = list(filter(lambda c: field.startswith(c), conditions))[0]
             (p, _) = conditions[condKey](p, field)
+
+    return p
+
+def type_check_implication(p:bool, rule:Union[dict]) -> bool:
+    (p, c) = assert_type(p, rule, dict, 'Implication rule should be a dictionary with an "lhs" and an "rhs" field, got "%s" instead' % str(rule))
+    if not c:
+        return False
+
+    if 'lhs' in rule:
+        p = type_check_cond(p, rule['lhs'])
+    else:
+        printe('Implication rule requires "lhs" key')
+        p = False
+
+    if 'rhs' in rule:
+        p = type_check_cond(p, rule['rhs'])
+    else:
+        printe('Implication rule requires "rhs" key')
+        p = False
 
     return p
 

--- a/examples/colour-map-candy.yml
+++ b/examples/colour-map-candy.yml
@@ -8,6 +8,4 @@
 - name: white-cap
   cap-style: 'ffffff'
   glyph-style: 'bb0000'
-  cond:
-    key-name:
-    - .*
+  cond: true

--- a/examples/colour-map-candy.yml
+++ b/examples/colour-map-candy.yml
@@ -1,0 +1,13 @@
+- name: red-cap
+  cap-style: 'bb0000'
+  glyph-style: 'ffffff'
+  cond:
+    any:
+      key-pos: (X + Y) % 2 <= 0.75
+      key-name: ''
+- name: white-cap
+  cap-style: 'ffffff'
+  glyph-style: 'bb0000'
+  cond:
+    key-name:
+    - .*

--- a/examples/colour-map-toofestive.yml
+++ b/examples/colour-map-toofestive.yml
@@ -1,19 +1,22 @@
 - name: specials
   cap-style: 'ffff00'
   glyph-style: 'fill:#ff8000'
-  keys:
-  - Esc
-  - Enter
+  cond:
+    key-name:
+    - Esc
+    - Enter
 - name: alphas
   cap-style: '00ff00'
   glyph-style: 'fill:#ff0000;'
-  keys:
-  - .-.+
-  - '[^+/*-]'
-  - ''
-  - F[1-49][0-2]?
+  cond:
+    key-name:
+      - .-.+
+      - '[^+/*-]'
+      - ''
+      - F[1-49][0-2]?
 - name: mods
   cap-style: 'ff0000'
   glyph-style: '00ff00'
-  keys:
-  - .*
+  cond:
+    key-name:
+      - .*

--- a/examples/colour-map-toofestive.yml
+++ b/examples/colour-map-toofestive.yml
@@ -17,6 +17,4 @@
 - name: mods
   cap-style: 'ff0000'
   glyph-style: '00ff00'
-  cond:
-    key-name:
-      - .*
+  cond: true

--- a/examples/colour-map.yml
+++ b/examples/colour-map.yml
@@ -1,13 +1,22 @@
 - name: green
   cap-style: '32a852'
   glyph-style: 'fill:#ad1aad;'
-  keys:
-  - .-.+
-  - '[^+/*-]'
-  - ''
-  - F[1-49][0-2]?
+  cond:
+    not-all:
+      key-name:
+      - ↑
+      - →
+      - ↓
+      - ←
+      key-pos: y > 5.5
+    key-name:
+    - .-.+
+    - '[^+/*-]'
+    - ''
+    - F[1-49][0-2]?
 - name: purple
   cap-style: 'ad1aad'
   glyph-style: '32a852'
-  keys:
-  - .*
+  cond:
+    key-name:
+    - .*

--- a/examples/colour-map.yml
+++ b/examples/colour-map.yml
@@ -2,6 +2,11 @@
   cap-style: '32a852'
   glyph-style: 'fill:#ad1aad;'
   cond:
+    key-name:
+    - .-.+
+    - '[^+/*-]'
+    - ''
+    - F[1-49][0-2]?
     not-all:
       key-name:
       - ↑
@@ -9,11 +14,6 @@
       - ↓
       - ←
       key-pos: y > 5.5
-    key-name:
-    - .-.+
-    - '[^+/*-]'
-    - ''
-    - F[1-49][0-2]?
 - name: purple
   cap-style: 'ad1aad'
   glyph-style: '32a852'

--- a/examples/colour-map.yml
+++ b/examples/colour-map.yml
@@ -17,6 +17,4 @@
 - name: purple
   cap-style: 'ad1aad'
   glyph-style: '32a852'
-  cond:
-    key-name:
-    - .*
+  cond: True

--- a/examples/colour-map.yml
+++ b/examples/colour-map.yml
@@ -17,4 +17,4 @@
 - name: purple
   cap-style: 'ad1aad'
   glyph-style: '32a852'
-  cond: True
+  cond: true


### PR DESCRIPTION
### What's changed?

Previously, it was only possible to constrain colour map rule usage by the name of the key they were applied to.
Now, it is possible to also involve the position of the key and the name/path of the layout file being used.
Composite rules have been added which allow multiple conditions to feed into a single truth value allowing, for example, the activation of some rules only in response to some input layouts.

Appropriate documentation and some examples has been added to the readme.

### Check lists

- [x] Compiled with Cython
