### PR TITLE
Replace Cairo with ImageMagick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ requirements.txt: $(ADJUST_KEYS_SRCS)
 ChangeLog.md: change-log.sh change-log-format.awk
 	./$< > $@
 
-adjustkeys/adjustkeys_addon.py: adjustkeys/adjustkeys_addon.py.in adjustkeys/args.py addongen $(ADJUST_KEYS_SRCS)
+adjustkeys/adjustkeys_addon.py: adjustkeys/adjustkeys_addon.py.in adjustkeys/args.py addongen $(ADJUST_KEYS_SRCS) requirements.txt
 	./addongen adjustkeys/adjustkeys.py < $< > $@
 
 profiles/%/profile_data.yml: profiles/%/profile_data.csv profiles/%/profile_data.yml.in profile_data.awk

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ If you’re new around text-editors, I’d recommend [VSCodium][codium], a minim
 You’ll need a working installation of Blender.
 
 1. Go to the [releases page][releases] and download `adjust-keys-blender-addon.zip`
-2. Install the addon by going to _Edit > Preferences > Add-ons > Install,_ and install the zip you just downloaded and activate the plugin (tick the tick-box)
+2. Install [ImageMagick][imagemagick] by following [this quick guide][imagemagick-install-guide]
+3. Install the addon by going to _Edit > Preferences > Add-ons > Install,_ and install the zip you just downloaded and activate the plugin (tick the tick-box)
 	- (Optional) If it doesn’t already appear, you may need to search the preferences window for `Adjustkeys`.
-3. Go to _Properties > Scene Properties > Adjustkeys_ to see the menu
-4. Press _place caps and glyphs_
-5. Wait a moment, et voilà!
+4. Go to _Properties > Scene Properties > Adjustkeys_ to see the menu
+5. Press _place caps and glyphs_
+6. Wait a moment, et voilà!
 
 See the [custom setup section](#custom-setup) for how to change the stock settings into your own keycap set.
 
@@ -92,10 +93,11 @@ See the [custom setup section](#custom-setup) for how to change the stock settin
 
 If you want to use `adjustkeys` through another python script for the purpose of automating something a script:
 
-1. Go to the [releases page][releases], download `adjust-keys.zip` and unzip it so that the `adjustkeys-bin` binary somewhere you won’t accidentally delete it
+1. Install [ImageMagick][imagemagick] by following [this quick guide][imagemagick-install-guide]
+2. Go to the [releases page][releases], download `adjust-keys.zip` and unzip it so that the `adjustkeys-bin` binary somewhere you won’t accidentally delete it
 	- If you want to automate the process (e.g. through `git submodule`), running `make -C /path/to/adjust-keys/ devel` will make a binary and necessary data files
-2. Copy the path where `adjustkeys` now is (I have mine in `/home/kcza/Documents/keys/adjustkeys-bin`)
-3. In your existing Python script add the following lines, appropriately substituting the path from the previous step:
+3. Copy the path where `adjustkeys` now is (I have mine in `/home/kcza/Documents/keys/adjustkeys-bin`)
+4. In your existing Python script add the following lines, appropriately substituting the path from the previous step:
 
 ```python
 from sys import path
@@ -370,6 +372,8 @@ Please ensure that credit is given where it is due.
 [open-cherry-font]: ihttps://github.com/dakotafelder/open-cherry
 [pip]: https://pip.pypa.io/en/stable/
 [python]: https://www.python.org
+[imagemagick]: https://en.wikipedia.org/wiki/ImageMagick
+[imagemagick-install-guide]: https://docs.wand-py.org/en/latest/guide/install.html
 [quicksand]: https://fonts.google.com/specimen/Quicksand?query=quicksa
 [red-hat-display]: https://fonts.google.com/specimen/Red+Hat+Display
 [regex-help]: https://docs.python.org/3/howto/regex.html

--- a/addongen
+++ b/addongen
@@ -6,7 +6,7 @@ from adjustkeys.util import rem
 from adjustkeys.version import version
 from adjustkeys.yaml_io import read_yaml
 from deps import external_dependencies
-from sys import argv, stdin
+from sys import argv, stdin, stderr
 
 def main(progName:str) -> None:
     if progName.endswith('.py'):
@@ -141,7 +141,19 @@ def op_name(dest:str) -> str:
 def dependencies(insertion_file:str) -> [[str, str]]:
     ext_deps:[str] = external_dependencies(insertion_file)
     dep_origin_map:[str] = { v:k for k,v in read_yaml('pipreqs_module_map.yml').items() }
-    return [ (pkg, dep_origin_map[pkg]) for pkg in ext_deps if pkg in dep_origin_map ]
+    deps:[[str,str]] =  [ (pkg, dep_origin_map[pkg]) for pkg in ext_deps if pkg in dep_origin_map ]
+
+    pipreqs_deps:[str]
+    with open('requirements.txt', 'r') as f:
+        pipreqs_deps = list(map(lambda l: l.split('==')[0], f.readlines()))
+
+    python_native_deps:[str] = [ 'futures' ] # futures is included in the Python3 standard library, but not that of Python2 (it can be ignored)
+    missing_deps:[str] = [ pkg for _,pkg in deps if pkg not in pipreqs_deps and pkg not in python_native_deps ]
+    if missing_deps != []:
+        print('WARNING: Some dependencies are missing from the mapping file:\n\t%s' % '\n\t'.join(missing_deps), file=stderr)
+        exit(1)
+
+    return deps
 
 if __name__ == '__main__':
     if len(argv) < 2:

--- a/adjustkeys/adjustcaps.py
+++ b/adjustkeys/adjustcaps.py
@@ -18,8 +18,8 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from copy import deepcopy
 from math import inf, pi
 from mathutils import Euler, Matrix, Vector
-from os import makedirs, remove
-from os.path import basename, exists, join
+from os import access, makedirs, remove, strerror, W_OK
+from os.path import basename, exists, expanduser, join
 from re import IGNORECASE, match
 from statistics import mean
 from sys import argv, exit
@@ -54,7 +54,10 @@ def adjust_caps(layout: [dict], colour_map:[dict], profile_data:dict, collection
             printi('Preparing individual materials')
             colourMaterials = generate_shrink_wrap_materials(pargs.use_existing_materials, colour_map, caps)
         else:
-            uv_image_path = abspath('//' + capmodel_name + '_uv_image.png')
+            uv_image_base:str = capmodel_name + '_uv_image.png'
+            uv_image_path = abspath('//' + uv_image_base)
+            if not check_permissions(uv_image_path, W_OK):
+                uv_image_path = expanduser(join('~', 'Downloads', uv_image_base))
 
             printi('Handling material')
             (imgNode, colourMaterials) = generate_uv_map_materials(pargs.use_existing_materials, uv_image_path, capmodel_name, caps)
@@ -97,6 +100,13 @@ def adjust_caps(layout: [dict], colour_map:[dict], profile_data:dict, collection
             uv_unwrap(obj, profile_data['unit-length'] * profile_data['scale'] * layout_dims, pargs.partition_uv_by_face_direction)
 
     return { 'keycap-model-name': importedModelName, 'material-names': colourMaterials, '~caps-with-margin-offsets': caps, '~texture-image-node': imgNode, 'uv-image-path': uv_image_path, 'uv-material-name': uv_material_name }
+
+def check_permissions(fpath:str, perms:int) -> bool:
+    try:
+        return access(fpath, perms)
+    except IOError as ioe:
+        printe(strerror(ioe))
+        return False
 
 def generate_capmodel_name(intended_name:str) -> str:
     name:str = intended_name

--- a/adjustkeys/adjustcaps.py
+++ b/adjustkeys/adjustcaps.py
@@ -6,7 +6,7 @@ from .args import parse_args
 from .blender_available import blender_available
 from .layout import get_layout, parse_layout
 from .lazy_import import LazyImport
-from .log import die, init_logging, printi, printw, print_warnings
+from .log import die, init_logging, printe, printi, printw, print_warnings
 from .obj_io import read_obj, write_obj
 from .path import walk
 from .positions import resolve_cap_position

--- a/adjustkeys/adjustglyphs.py
+++ b/adjustkeys/adjustglyphs.py
@@ -15,7 +15,6 @@ from .scale import get_scale
 from .shrink_wrap import shrink_wrap_glyphs_to_keys
 from .util import concat, dict_union, frange, get_dicts_with_duplicate_field_values, get_only, inner_join, right_outer_join, list_diff, rob_rem, safe_get
 from .yaml_io import read_yaml, write_yaml
-from cairosvg import svg2png
 from functools import reduce
 from os import remove
 from os.path import basename, exists, join
@@ -24,6 +23,8 @@ from mathutils import Matrix, Vector
 from re import IGNORECASE, match
 from sys import argv, exit
 from types import LambdaType
+from wand.color import Color as Colour
+from wand.image import Image
 from xml.dom.minidom import Element, parseString
 Collection:type = None
 if blender_available():
@@ -125,37 +126,35 @@ def import_and_align_glyphs_as_curves(scale:float, profile_data:dict, keycapMode
 
 def import_and_align_glyphs_as_raster(svg:str, imgNode:ShaderNodeTexImage, uv_image_path:str, uv_material_name:str, layout_dims:Vector, uv_res:float, partition_uv_by_face_direction:bool):
     # Convert to png
+    #  from cairosvg import svg2png
+    #  m:float = min((Matrix.Diagonal((1, 2)) @ layout_dims) if partition_uv_by_face_direction else layout_dims)
+    #  uv_dims:Vector = (uv_res / m) * layout_dims
+    #  svg2png_params:dict = {
+        #  'parent_width': int(uv_dims.x),
+        #  'parent_height': int(uv_dims.y),
+        #  'scale': m,
+        #  #  'unsafe': True,
+        #  'output_width': int(uv_dims.x),
+        #  'output_height': int(uv_dims.y) * (2 if partition_uv_by_face_direction else 1), # Who knows why this is required for the cairo method, but it seems to do the job
+        #  'write_to': uv_image_path,
+    #  }
+    #  svg2png(svg, **svg2png_params)
+
+    png:bytes
     m:float = min((Matrix.Diagonal((1, 2)) @ layout_dims) if partition_uv_by_face_direction else layout_dims)
     uv_dims:Vector = (uv_res / m) * layout_dims
-    svg2png_params:dict = {
-        'parent_width': int(uv_dims.x),
-        'parent_height': int(uv_dims.y),
-        'scale': m,
-        #  'unsafe': True,
-        'output_width': int(uv_dims.x),
-        'output_height': int(uv_dims.y) * (2 if partition_uv_by_face_direction else 1), # Who knows why this is required for the cairo method, but it seems to do the job
-        'write_to': uv_image_path,
-    }
-    svg2png(svg, **svg2png_params)
-
-    #  # Unused wand (ImageMagick API) code, functions correctly but one day decided to stop because even a 1x1 pixel image apparently exceeded maximum width/height limits. The following imports are required.
-    #  from wand.color import Color as Colour
-    #  from wand.image import Image
-    #  png:bytes
-    #  with Colour('transparent') as transparent:
-        #  m:float = min((Matrix.Diagonal((1, 2)) @ layout_dims) if partition_uv_by_face_direction else layout_dims)
-        #  uv_dims:Vector = (uv_res / m) * layout_dims
-        #  image_params:dict = {
-            #  'blob': svg.encode('utf-8'),
-            #  'format': 'svg',
-            #  'background': transparent,
-            #  'width': int(uv_dims.x),
-            #  'height': int(uv_dims.y),
-        #  }
-        #  with Image(**image_params) as image:
-            #  png = image.make_blob(format='png')
-    #  with open(uv_image_path, 'wb+') as ofile:
-        #  ofile.write(png)
+    with Colour('transparent') as transparent:
+        image_params:dict = {
+            'blob': svg.encode('utf-8'),
+            'format': 'svg',
+            'background': transparent,
+            'width': int(uv_dims.x),
+            'height': int(uv_dims.y),
+        }
+        with Image(**image_params) as image:
+            png = image.make_blob(format='png')
+    with open(uv_image_path, 'wb+') as ofile:
+        ofile.write(png)
 
     # Add image to Blender's database if absent otherwise update
     bpy_internal_uv_image_name:str = basename(uv_image_path)

--- a/adjustkeys/adjustkeys_addon.py.in
+++ b/adjustkeys/adjustkeys_addon.py.in
@@ -11,8 +11,16 @@ from importlib import reload
 from inspect import getmembers
 from math import ceil, log10
 from os.path import dirname
+from platform import system
 from subprocess import CalledProcessError
-from sys import path
+from sys import path, version_info
+
+# Allow site-packages to contain dll files (e.g. where the user needs to copy them in due to missing installers / packages)
+if version_info >= (3,8):
+    from os import add_dll_directory
+    from os.path import join
+    add_dll_directory(join(dirname(__file__), 'site-packages'))
+
 
 bl_info = {
         'name': 'adjustkeys',
@@ -40,12 +48,18 @@ configurable_arg_dests = list(map(lambda a: a['dest'], configurable_args))
 
 Dependency = namedtuple('Dependency', ['module', 'package', 'name'])
 
+imagemagick_url = 'https://docs.wand-py.org/en/latest/guide/install.html'
+
 dependencies = [ DEPENDENCY_LIST ]
 dependencyWarningLines = [
-        "If you’re seeing this, it means that adjustkeys is missing some dependencies. Before installing these, you should note the following.",
+        "Adjustkeys is missing some dependencies. You need to do TWO things:",
+        "1. Install the ImageMagick library (manual, sorry)",
+        "2. Install python dependencies (automatic :D).",
+        "ImageMagick is most easily installed by following the guide at %s" % imagemagick_url,
+        "Before installing the python dependencies please note the following.",
         "Firstly, an internet connection will be used to download the necessary packages.",
         "Secondly, depending on the your setup, you may need to run Blender with elevated privileges. This is not advisable in the general case as external code will be executed, so please don’t do this if you don’t need to.",
-        "The following python packages (and their respective dependencies) are required:"
+        "The following python packages (and their respective dependencies) are will be downloaded:"
     ] + list(map(lambda d: '∙ %s' % d.package, sorted(dependencies, key=lambda d: d.package.lower()))) + [
         "To install these, press the button below and this message should disappear. DO NOT QUIT BLENDER WHILE DEPENDENCIES ARE INSTALLING as the side-effects of this action are undefined. Open the system console to see what’s happening behind the scenes."
     ]
@@ -181,7 +195,7 @@ class KCZA_Preferences(AddonPreferences):
                 layout.label(text=line)
             layout.operator(KCZA_OT_InstallDependencies.bl_idname, icon='CONSOLE')
         else:
-            messageText = [ 'Dependency status: OK' ]
+            messageText = [ 'Python dependency status: OK' ]
             for line in dumb_wrap_text(messageText, self.message_width):
                 layout.label(text=line)
 

--- a/pipreqs_module_map.yml
+++ b/pipreqs_module_map.yml
@@ -63,6 +63,7 @@ Brownie: brownie
 Bugzilla_ETL: bzETL
 BuildNotify: buildnotifylib
 BuildbotEightStatusShields: BuildbotStatusShields
+CairoSVG: cairosvg
 Cartridge: cartridge
 CassandraLauncher: cassandralauncher
 Cerberus: cerberus
@@ -736,6 +737,7 @@ unicode_slugify: slugify
 useless.pipes: useless
 virtualenv_clone: clonevirtualenv
 vnc2flv: flvscreen
+Wand: wand
 weblogo: weblogolib
 websocket_client: websocket
 webunit: demo


### PR DESCRIPTION
### What's changed?

Previously, libcairo was used for svg to png conversion, but this is now replaced with ImageMagick with as the latter has a _much_ easier installation process than the former for the lay-user, especially on Windows.
A minor permissions issue with the uv file writing location when no `.blend` file is open has also been fixed.

### Check lists

- [x] Compiled with Cython
